### PR TITLE
WIP: Using git LFS depending on Project settings

### DIFF
--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -81,6 +81,7 @@ export default class ElekIoCore {
       this.assetService
     );
     this.projectService = new ProjectService(
+      this.logService,
       this.version,
       this.options,
       this.jsonFileService,

--- a/src/schema/gitSchema.ts
+++ b/src/schema/gitSchema.ts
@@ -45,6 +45,7 @@ export const gitInitOptionsSchema = z.object({
    * Use the specified name for the initial branch in the newly created repository. If not specified, fall back to the default name (currently master, but this is subject to change in the future; the name can be customized via the init.defaultBranch configuration variable).
    */
   initialBranch: z.string(),
+  lfs: z.boolean(),
 });
 export type GitInitOptions = z.infer<typeof gitInitOptionsSchema>;
 

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -18,6 +18,9 @@ export const projectSettingsSchema = z.object({
     default: supportedLanguageSchema,
     supported: z.array(supportedLanguageSchema),
   }),
+  git: z.object({
+    lfs: z.boolean(),
+  }),
 });
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -29,7 +29,6 @@ export const projectFolderSchema = z.enum([
   'collections',
   'shared-values',
   'lfs',
-  // 'logs',
   // 'public',
   // 'theme',
 ]);

--- a/src/service/GitService.ts
+++ b/src/service/GitService.ts
@@ -79,7 +79,9 @@ export class GitService {
 
     await this.git(path, args);
     await this.setLocalConfig(path);
-    await this.installLfs(path);
+    if (options?.lfs === true) {
+      await this.installLfs(path);
+    }
   }
 
   /**
@@ -461,6 +463,32 @@ export class GitService {
   }
 
   /**
+   * Installs LFS support and starts tracking
+   * all files inside the lfs folder
+   *
+   * @param path Path to the repository
+   * @todo If the user installs LFS after adding one or more Assets, we need to migrate the object files into their corresponding pointer files
+   * @see https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.adoc
+   * @see https://docs.github.com/en/repositories/working-with-files/managing-large-files/moving-a-file-in-your-repository-to-git-large-file-storage
+   */
+  public async installLfs(path: string): Promise<void> {
+    await this.git(path, ['lfs', 'install']);
+    await this.git(path, ['lfs', 'track', 'lfs/*']);
+  }
+
+  /**
+   * Uninstalls LFS support and stops tracking
+   * all files inside the lfs folder
+   *
+   * @param path Path to the repository
+   * @todo If the user uninstalls LFS after adding one or more Assets, we need to migrate the pointer files into their corresponding object files again
+   * @see https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.adoc
+   */
+  public async uninstallLfs(path: string): Promise<void> {
+    await this.git(path, ['lfs', 'uninstall']);
+  }
+
+  /**
    * Reads the currently used version of Git
    *
    * This can help debugging
@@ -493,17 +521,6 @@ export class GitService {
    */
   private async checkBranchOrTagName(path: string, name: string) {
     await this.git(path, ['check-ref-format', '--allow-onelevel', name]);
-  }
-
-  /**
-   * Installs LFS support and starts tracking
-   * all files inside the lfs folder
-   *
-   * @param path Path to the repository
-   */
-  private async installLfs(path: string): Promise<void> {
-    await this.git(path, ['lfs', 'install']);
-    await this.git(path, ['lfs', 'track', 'lfs/*']);
   }
 
   /**

--- a/src/service/LogService.ts
+++ b/src/service/LogService.ts
@@ -65,6 +65,6 @@ export class LogService {
   }
 
   public read(options?: QueryOptions) {
-    this.logger.query(options);
+    return this.logger.query(options);
   }
 }

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -108,6 +108,9 @@ export class ProjectService
         default: user.language,
         supported: [user.language],
       },
+      git: {
+        lfs: false,
+      },
     };
 
     const projectFile: ProjectFile = {
@@ -130,7 +133,10 @@ export class ProjectService
     try {
       await this.createFolderStructure(projectPath);
       await this.createGitignore(projectPath);
-      await this.gitService.init(projectPath, { initialBranch: 'main' });
+      await this.gitService.init(projectPath, {
+        initialBranch: 'main',
+        lfs: projectFile.settings.git.lfs,
+      });
       await this.jsonFileService.create(
         projectFile,
         pathTo.projectFile(id),
@@ -228,6 +234,9 @@ export class ProjectService
           default:
             props.settings?.language.default ||
             prevProjectFile.settings.language.default,
+        },
+        git: {
+          lfs: props.settings?.git.lfs || prevProjectFile.settings.git.lfs,
         },
       },
       updated: datetime(),


### PR DESCRIPTION
The idea was to allow the user to switch between using LFS for supported hosters like Github and Bitbucket. The problem I ran into was that Git LFS migrate rewrites the history which then requires a force push to the remote. For the migrate import, there is an option `--no-rewrite` available to not alter the history but add a new commit instead. This option does not seem to exist for the migrate export command. 

I don't believe requiring the user to force push is the right way to go - at least as an officially supported feature of elek.io. Therefore I am not going to proceed with this idea for now. If anyone has a good idea how to solve this differently, let me know.