### PR TITLE
Optimize internal datastructures & added Release & migration workflow

### DIFF
--- a/.changeset/blue-rocks-invite.md
+++ b/.changeset/blue-rocks-invite.md
@@ -1,0 +1,11 @@
+---
+'@elek-io/core': minor
+---
+
+- Git commit messages now use human-readable subject lines with git trailers (Method:, Object-Type:, Object-Id:, Collection-Id:) instead of JSON.stringify
+- Git tag messages use a typed GitTagMessage discriminated union (release, preview, upgrade) serialized as git trailers (Type:, Version:, Core-Version:)
+- Removed releaseTypeSchema and releaseTagMessageSchema from releaseSchema.ts — tag message typing now lives in gitSchema.ts
+- Tightened Zod schemas: commit hash uses z.hash('sha1'), datetimes use z.iso.datetime(), migrateProjectSchema uses z.looseObject()
+- Fixed email truncation bug in GitTagService.list() caused by a redundant slice(0, -1)
+- Added pipe-character validation on gitSignatureSchema.name to prevent delimiter collision in parsed output
+- Changed parseTagTrailers to return null and log a warning for unrecognized tag types instead of throwing

--- a/.changeset/lazy-history-separate.md
+++ b/.changeset/lazy-history-separate.md
@@ -1,0 +1,5 @@
+---
+'@elek-io/core': minor
+---
+
+Separated git history from CRUD return values for improved performance. `history` and `fullHistory` are no longer included on `Project`, `Collection`, `Entry`, and `Asset` objects. Use the new `history()` method on each service instead (e.g. `core.projects.history({ id })`, `core.entries.history({ projectId, collectionId, id })`).

--- a/.changeset/sixty-parents-push.md
+++ b/.changeset/sixty-parents-push.md
@@ -1,0 +1,6 @@
+---
+'@elek-io/core': minor
+---
+
+- Access entry values by meaningful names: `entry.values.title` instead of `entry.values.find(v => v.fieldDefinitionId === '550e8400-...')`
+- Reference collections by slug in API routes: `/collections/blog-posts/entries` instead of `/collections/550e8400-.../entries` and the astro integration

--- a/.changeset/stale-nails-appear.md
+++ b/.changeset/stale-nails-appear.md
@@ -1,0 +1,5 @@
+---
+'@elek-io/core': minor
+---
+
+New `ReleaseService` that diffs the `work` branch against `production` to detect collection and field definition changes, computes the appropriate semver bump (major/minor/patch), and supports creating full releases and preview releases with git tags.

--- a/.changeset/warm-chains-migrate.md
+++ b/.changeset/warm-chains-migrate.md
@@ -1,0 +1,6 @@
+---
+'@elek-io/core': minor
+---
+
+- Added a migration chain for outdated files (reading from git history and upgrading to the latest schema version)
+- Added documentation for the migration and history-reading flow in `docs/migration-and-history-flow.md`

--- a/README.md
+++ b/README.md
@@ -2,13 +2,36 @@
 
 [![codecov](https://codecov.io/gh/elek-io/core/graph/badge.svg?token=GSZIZMVG6Q)](https://codecov.io/gh/elek-io/core)
 
-Handles core functionality of elek.io Projects like file IO and version control as well as providing schemas and types.
+Handles core functionality of elek.io Projects like file IO and version control as well as providing schemas, types and a local REST API.
+
+## Installation
+
+```bash
+npm install @elek-io/core
+```
+
+## Exports
+
+The package provides multiple entry points for different environments:
+
+- **Node** (`@elek-io/core`) — The `ElekIoCore` main class with full access to services, API, schemas and utilities.
+- **Browser** (`@elek-io/core`) — All schemas and types but without the `ElekIoCore` class, since it is not usable in a browser environment.
+- **Astro** (`@elek-io/core/astro`) — Astro content loaders `elekAssets()` and `elekEntries()` for loading Project data into Astro.
+- **CLI** (`elek`) — A command-line interface with commands for generating API clients, starting a local API and exporting Projects.
+
+## Source structure
 
 ```
 |-- src
 |   |-- api
-|   |   Exports a local API that allows reading Project data
-|   |   mainly for development of websites or apps on the same device.
+|   |   Local REST API built on Hono with OpenAPI documentation.
+|   |   Provides routes for Projects, Collections, Entries and Assets.
+|   |-- astro
+|   |   Astro integration with content loaders and dynamic schema building
+|   |   based on Collection Field definitions.
+|   |-- cli
+|   |   Command-line interface with commands:
+|   |   generate:client, api:start and export.
 |   |-- error
 |   |   Different classes extending Error.
 |   |-- schema
@@ -17,6 +40,9 @@ Handles core functionality of elek.io Projects like file IO and version control 
 |   |   Contains CRUD logic that does file-io as well as utility functions.
 |   |   The methods are mostly used as endpoints
 |   |   so their input is validated against our zod schemas.
+|   |   |-- migrations
+|   |   |   Version-aware schema migrations for Projects, Assets,
+|   |   |   Collections and Entries.
 |   |-- test
 |   |   Additional files and utility functions only used for testing.
 |   |-- util
@@ -28,9 +54,13 @@ Handles core functionality of elek.io Projects like file IO and version control 
 |   |-- index.node.ts
 |   |   Exports the ElekIoCore main class which makes the services and API
 |   |   endpoints accessible as well as schemas and utility functions.
+|   |-- index.astro.ts
+|   |   Exports the Astro content loaders for Assets and Entries.
+|   |-- index.cli.ts
+|   |   Entry point for the CLI binary.
 ```
 
-## The concept behind Projects, Collections, Entries, Values and Assets
+## The concept behind Projects, Collections, Entries, Values, Assets and Releases
 
 ```
 |-- Project - e.g. "Website"
@@ -40,6 +70,7 @@ Handles core functionality of elek.io Projects like file IO and version control 
 |   |   |   |-- Value - e.g for a post's title: "Quarterly results 7% higher than expected"
 |   |   |   |-- Asset - a reference to a previously added Asset like image, PDF or ZIP
 |   |   |   |-- Entry - a reference to another Entry e.g. to show the user related posts
+|   |-- Release - e.g. "v1.0.0" - a tagged snapshot of the Project at a specific point in time
 ```
 
 ### Projects
@@ -57,7 +88,7 @@ e.g. for a Blog, it could have the following Field definition for each post / En
 - an author that wrote the post (Entry reference)
 
 Each definition like the title, contains additional information for the input Field, that is used to modify it's Value.
-e.g. the title would be a simple one line input Field, that has a maximum lenght of 150 characters and is required for each post. But the content is a markdown editor to easily add formatting. The image let's the user select a jpeg or png from disk. And the author is a reference to another Collection's Entry, so the user is able to choose one of them.
+e.g. the title would be a simple one line input Field, that has a maximum length of 150 characters and is required for each post. But the content is a markdown editor to easily add formatting. The image let's the user select a jpeg or png from disk. And the author is a reference to another Collection's Entry, so the user is able to choose one of them.
 
 ### Entries
 
@@ -65,9 +96,39 @@ Contains Values and references that follow the Collection's Field definitions. W
 
 ### Values
 
-Represent either a single piece of data like the string "How to be successfull in 3 easy steps", a number or a boolean - or a reference to Assets or other Entries.
+Represent either a single piece of data like the string "How to be successful in 3 easy steps", a number or a boolean - or a reference to Assets or other Entries.
 
 ### Assets
 
 Are files / blobs like images (png, jpeg etc.), documents (excel sheets etc.), music or a compressed folder.
 Assets have two files inside the Project's repository - the actual file and additionally a file containing meta information like the size.
+
+### Releases
+
+Are tagged snapshots of a Project at a specific point in time, managed through git tags. They allow you to mark stable versions of your content that can be deployed or exported.
+
+## CLI
+
+The package includes a CLI accessible via the `elek` command:
+
+- `elek generate:client` — Generate a JavaScript/TypeScript API client (ESM or CJS)
+- `elek api:start` — Start a local REST API server (default port 31310)
+- `elek export` — Export Projects to JSON (nested or as separate files)
+
+## Documentation
+
+The `docs/` folder contains additional in-depth documentation on specific topics like the migration and history reading flow.
+
+## Development
+
+```bash
+pnpm install       # Install dependencies
+pnpm dev           # Run tests in watch mode
+pnpm test          # Run tests once
+pnpm coverage      # Run tests with coverage
+pnpm build         # Build all entry points
+pnpm lint          # Lint
+pnpm check-types   # Type check
+pnpm check-format  # Check formatting
+pnpm format        # Format code
+```

--- a/docs/migration-and-history-flow.md
+++ b/docs/migration-and-history-flow.md
@@ -38,12 +38,12 @@ Find migration where migration.from === data.coreVersion
 
 Each service has its own migration array under `src/service/migrations/`:
 
-| File | Service |
-|------|---------|
-| `assetMigrations.ts` | AssetService |
+| File                      | Service           |
+| ------------------------- | ----------------- |
+| `assetMigrations.ts`      | AssetService      |
 | `collectionMigrations.ts` | CollectionService |
-| `entryMigrations.ts` | EntryService |
-| `projectMigrations.ts` | ProjectService |
+| `entryMigrations.ts`      | EntryService      |
+| `projectMigrations.ts`    | ProjectService    |
 
 To add a migration, append a `Migration` object to the relevant array:
 

--- a/docs/migration-and-history-flow.md
+++ b/docs/migration-and-history-flow.md
@@ -1,0 +1,183 @@
+# Migration and History Reading Flow
+
+This document describes how Projects are upgraded to a new Core version and how objects are read from git history.
+
+## Migration Chain
+
+Every service (Asset, Collection, Entry, Project) has a `migrate()` method that transforms a potentially outdated JSON file into the current schema. The migration follows three stages:
+
+1. **Loose parse** — validate with `migrateXSchema` (relaxed schema that accepts any `coreVersion`)
+2. **Apply migration chain** — walk through registered `Migration` steps from the file's `coreVersion` to the target version
+3. **Strict parse** — validate the result with the current `xFileSchema`
+
+### `applyMigrations(data, migrations, targetVersion)`
+
+The shared helper in `src/service/migrations/applyMigrations.ts` drives the chain:
+
+```
+Input data (structuredClone'd to prevent mutation)
+  |
+  v
+Is data.coreVersion === targetVersion? --yes--> return data
+  |
+  no
+  v
+Find migration where migration.from === data.coreVersion
+  |
+  +--> Found: run migration, stamp coreVersion = migration.to, loop back
+  |
+  +--> Not found: stamp coreVersion = targetVersion, return (backward-compatible gap)
+```
+
+- Migrations are exact version matches (`from: '1.0.0'`), not semver ranges
+- Each `Migration.run()` is a pure function — it must not mutate input or set `coreVersion`
+- `applyMigrations` stamps `coreVersion` after each step
+- If no migration exists for a version gap, the data is assumed backward-compatible
+
+### Migration files
+
+Each service has its own migration array under `src/service/migrations/`:
+
+| File | Service |
+|------|---------|
+| `assetMigrations.ts` | AssetService |
+| `collectionMigrations.ts` | CollectionService |
+| `entryMigrations.ts` | EntryService |
+| `projectMigrations.ts` | ProjectService |
+
+To add a migration, append a `Migration` object to the relevant array:
+
+```typescript
+// Example: src/service/migrations/projectMigrations.ts
+export const projectMigrations: Migration[] = [
+  {
+    from: '1.0.0',
+    to: '1.1.0',
+    run: (data) => {
+      // Transform data from 1.0.0 shape to 1.1.0 shape
+      const { oldField, ...rest } = data;
+      return { ...rest, newField: oldField };
+    },
+  },
+];
+```
+
+## Project Upgrade Flow
+
+`ProjectService.upgrade()` orchestrates upgrading an entire Project and all its objects to the current Core version.
+
+```
+upgrade({ id, force? })
+  |
+  v
+Switch to 'work' branch (if not already on it)
+  |
+  v
+Read project.json (unsafe read, no strict validation)
+  |
+  v
+Version checks:
+  - Project coreVersion > Core version? --> Error (client needs update)
+  - Project coreVersion === Core version and !force? --> Error (already up to date)
+  |
+  v
+List all Asset and Collection references
+  |
+  v
+Create upgrade branch: upgrade/core-{from}-to-{to}
+  |
+  v
+  +-- Upgrade all Assets (parallel)
+  |     For each: unsafeRead -> service.migrate() -> service.update()
+  |
+  +-- Upgrade all Collections (parallel)
+  |     For each: unsafeRead -> service.migrate() -> service.update()
+  |
+  +-- Upgrade all Entries (parallel per Collection)
+  |     For each: unsafeRead -> service.migrate() -> service.update()
+  |
+  v
+Migrate the Project file itself
+  |
+  v
+Switch back to 'work' branch
+  |
+  v
+Squash-merge upgrade branch into 'work'
+  |
+  v
+Commit with method: 'upgrade'
+  |
+  v
+Create git tag with upgrade metadata
+  |
+  v
+Delete upgrade branch
+  |
+  v
+Done (logged with previous + migrated state)
+```
+
+### Rollback on failure
+
+If any step inside the `try` block fails:
+
+1. Switch back to the `work` branch
+2. Force-delete the upgrade branch
+3. Re-throw the error
+
+The `work` branch remains unchanged since all upgrade work happened on the temporary upgrade branch.
+
+## Reading from Git History
+
+When `read()` is called with a `commitHash`, the service retrieves the file content at that specific commit and runs it through the migration chain. This ensures historical data is always returned in the current schema shape.
+
+### Project history read
+
+```
+read({ id, commitHash })
+  |
+  v
+gitService.getFileContentAtCommit(projectPath, projectFilePath, commitHash)
+  |
+  v
+JSON.parse(content)
+  |
+  v
+this.migrate(parsedJson)
+  |  Internally: loose parse -> applyMigrations -> strict parse
+  |
+  v
+toProject(projectFile)  -- resolves remoteOriginUrl
+  |
+  v
+Return Project
+```
+
+### Asset history read
+
+Same pattern, with an additional step to retrieve the binary asset file:
+
+```
+read({ projectId, id, commitHash })
+  |
+  v
+Get asset JSON at commit -> JSON.parse -> migrate()
+  |
+  v
+Get binary asset content at commit -> write to temp path
+  |
+  v
+toAsset(projectId, assetFile, commitHash)  -- uses temp path
+  |
+  v
+Return Asset
+```
+
+### Collection and Entry history reads
+
+Follow the same `getFileContentAtCommit -> JSON.parse -> migrate() -> toX()` pattern without additional file handling.
+
+### Why migrate on history reads?
+
+A file stored at commit `abc123` may have been written by Core v1.0.0 with a different schema shape. By running `migrate()`, the historical data is transformed through the migration chain to match the current schema, allowing callers to use a single consistent type regardless of when the data was written.

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -116,9 +116,25 @@ describe('API', function () {
 
   it('should be able to read a Collection via API', async function () {
     const res = await client.content.v1.projects[':projectId'].collections[
-      ':collectionId'
+      ':collectionIdOrSlug'
     ].$get({
-      param: { projectId: project.id, collectionId: collection.id },
+      param: { projectId: project.id, collectionIdOrSlug: collection.id },
+    });
+
+    expect(res.status).toEqual(200);
+    const readCollection = await res.json();
+    expect(core.collections.isCollection(readCollection)).toEqual(true);
+    expect(readCollection.id).toEqual(collection.id);
+  });
+
+  it('should be able to read a Collection by slug via API', async function () {
+    const res = await client.content.v1.projects[':projectId'].collections[
+      ':collectionIdOrSlug'
+    ].$get({
+      param: {
+        projectId: project.id,
+        collectionIdOrSlug: collection.slug.plural,
+      },
     });
 
     expect(res.status).toEqual(200);
@@ -143,9 +159,9 @@ describe('API', function () {
 
   it('should be able to list all Entries via API', async function () {
     const res = await client.content.v1.projects[':projectId'].collections[
-      ':collectionId'
+      ':collectionIdOrSlug'
     ].entries.$get({
-      param: { projectId: project.id, collectionId: collection.id },
+      param: { projectId: project.id, collectionIdOrSlug: collection.id },
       query: {},
     });
 
@@ -156,13 +172,30 @@ describe('API', function () {
     expect(entries.list.find((p) => p.id === entry.id)?.id).toEqual(entry.id);
   });
 
+  it('should be able to list all Entries by collection slug via API', async function () {
+    const res = await client.content.v1.projects[':projectId'].collections[
+      ':collectionIdOrSlug'
+    ].entries.$get({
+      param: {
+        projectId: project.id,
+        collectionIdOrSlug: collection.slug.plural,
+      },
+      query: {},
+    });
+
+    expect(res.status).toEqual(200);
+    const entries = await res.json();
+    expect(entries.list.length).toEqual(1);
+    expect(entries.list.find((p) => p.id === entry.id)?.id).toEqual(entry.id);
+  });
+
   it('should be able to read an Entry via API', async function () {
     const res = await client.content.v1.projects[':projectId'].collections[
-      ':collectionId'
+      ':collectionIdOrSlug'
     ].entries[':entryId'].$get({
       param: {
         projectId: project.id,
-        collectionId: collection.id,
+        collectionIdOrSlug: collection.id,
         entryId: entry.id,
       },
     });
@@ -175,9 +208,9 @@ describe('API', function () {
 
   it('should be able to count all Entries via API', async function () {
     const res = await client.content.v1.projects[':projectId'].collections[
-      ':collectionId'
+      ':collectionIdOrSlug'
     ].entries.count.$get({
-      param: { projectId: project.id, collectionId: collection.id },
+      param: { projectId: project.id, collectionIdOrSlug: collection.id },
     });
 
     expect(res.status).toEqual(200);

--- a/src/api/routes/content/v1/collections.ts
+++ b/src/api/routes/content/v1/collections.ts
@@ -100,9 +100,9 @@ const router = createRouter()
   .openapi(
     createRoute({
       summary: 'Get one Collection',
-      description: 'Retrieve a Collection by ID',
+      description: 'Retrieve a Collection by UUID or slug',
       method: 'get',
-      path: '/{projectId}/collections/{collectionId}',
+      path: '/{projectId}/collections/{collectionIdOrSlug}',
       tags,
       request: {
         params: z.object({
@@ -112,11 +112,12 @@ const router = createRouter()
               in: 'path',
             },
           }),
-          collectionId: uuidSchema.openapi({
+          collectionIdOrSlug: z.string().openapi({
             param: {
-              name: 'collectionId',
+              name: 'collectionIdOrSlug',
               in: 'path',
             },
+            description: 'Collection UUID or slug',
           }),
         }),
       },
@@ -132,10 +133,14 @@ const router = createRouter()
       },
     }),
     async (c) => {
-      const { projectId, collectionId } = c.req.valid('param');
+      const { projectId, collectionIdOrSlug } = c.req.valid('param');
+      const resolvedId = await c.var.collectionService.resolveCollectionId({
+        projectId,
+        idOrSlug: collectionIdOrSlug,
+      });
       const collection = await c.var.collectionService.read({
         projectId,
-        id: collectionId,
+        id: resolvedId,
       });
 
       return c.json(collection, 200);

--- a/src/api/routes/content/v1/entries.ts
+++ b/src/api/routes/content/v1/entries.ts
@@ -14,7 +14,7 @@ const router = createRouter()
       summary: 'List Entries',
       description: 'Lists all Entries of the given Projects Collection',
       method: 'get',
-      path: '/{projectId}/collections/{collectionId}/entries',
+      path: '/{projectId}/collections/{collectionIdOrSlug}/entries',
       tags,
       request: {
         params: z.object({
@@ -24,11 +24,12 @@ const router = createRouter()
               in: 'path',
             },
           }),
-          collectionId: uuidSchema.openapi({
+          collectionIdOrSlug: z.string().openapi({
             param: {
-              name: 'collectionId',
+              name: 'collectionIdOrSlug',
               in: 'path',
             },
+            description: 'Collection UUID or slug',
           }),
         }),
         query: z.object({
@@ -55,8 +56,12 @@ const router = createRouter()
       },
     }),
     async (c) => {
-      const { projectId, collectionId } = c.req.valid('param');
+      const { projectId, collectionIdOrSlug } = c.req.valid('param');
       const { limit, offset } = c.req.valid('query');
+      const collectionId = await c.var.collectionService.resolveCollectionId({
+        projectId,
+        idOrSlug: collectionIdOrSlug,
+      });
       const entries = await c.var.entryService.list({
         projectId,
         collectionId,
@@ -73,7 +78,7 @@ const router = createRouter()
       summary: 'Count Entries',
       description: 'Counts all Entries of the given Projects Collection',
       method: 'get',
-      path: '/{projectId}/collections/{collectionId}/entries/count',
+      path: '/{projectId}/collections/{collectionIdOrSlug}/entries/count',
       tags,
       request: {
         params: z.object({
@@ -83,11 +88,12 @@ const router = createRouter()
               in: 'path',
             },
           }),
-          collectionId: uuidSchema.openapi({
+          collectionIdOrSlug: z.string().openapi({
             param: {
-              name: 'collectionId',
+              name: 'collectionIdOrSlug',
               in: 'path',
             },
+            description: 'Collection UUID or slug',
           }),
         }),
       },
@@ -103,8 +109,15 @@ const router = createRouter()
       },
     }),
     async (c) => {
-      const { projectId, collectionId } = c.req.valid('param');
-      const count = await c.var.entryService.count({ projectId, collectionId });
+      const { projectId, collectionIdOrSlug } = c.req.valid('param');
+      const collectionId = await c.var.collectionService.resolveCollectionId({
+        projectId,
+        idOrSlug: collectionIdOrSlug,
+      });
+      const count = await c.var.entryService.count({
+        projectId,
+        collectionId,
+      });
 
       return c.json(count, 200);
     }
@@ -115,7 +128,7 @@ const router = createRouter()
       summary: 'Get one Entry',
       description: 'Retrieve an Entry by ID',
       method: 'get',
-      path: '/{projectId}/collections/{collectionId}/entries/{entryId}',
+      path: '/{projectId}/collections/{collectionIdOrSlug}/entries/{entryId}',
       tags,
       request: {
         params: z.object({
@@ -125,11 +138,12 @@ const router = createRouter()
               in: 'path',
             },
           }),
-          collectionId: uuidSchema.openapi({
+          collectionIdOrSlug: z.string().openapi({
             param: {
-              name: 'collectionId',
+              name: 'collectionIdOrSlug',
               in: 'path',
             },
+            description: 'Collection UUID or slug',
           }),
           entryId: uuidSchema.openapi({
             param: {
@@ -151,7 +165,11 @@ const router = createRouter()
       },
     }),
     async (c) => {
-      const { projectId, collectionId, entryId } = c.req.valid('param');
+      const { projectId, collectionIdOrSlug, entryId } = c.req.valid('param');
+      const collectionId = await c.var.collectionService.resolveCollectionId({
+        projectId,
+        idOrSlug: collectionIdOrSlug,
+      });
       const entry = await c.var.entryService.read({
         projectId,
         collectionId,

--- a/src/astro/schema.test.ts
+++ b/src/astro/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from '@hono/zod-openapi';
+import { v4 as uuid } from 'uuid';
 import type { FieldDefinition } from '../schema/fieldSchema.js';
 import { assetSchema } from '../schema/assetSchema.js';
 import {
@@ -11,7 +12,8 @@ describe('buildEntryValuesSchema', () => {
   it('generates schema for a text field definition', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        id: uuid(),
+        slug: 'title',
         valueType: 'string',
         fieldType: 'text',
         label: { en: 'Title' },
@@ -27,14 +29,15 @@ describe('buildEntryValuesSchema', () => {
     ];
 
     const schema = buildEntryValuesSchema(fieldDefs);
-    const valid = { 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': { en: 'Hello' } };
+    const valid = { title: { en: 'Hello' } };
     expect(schema.parse(valid)).toEqual(valid);
   });
 
   it('generates schema for a number field definition', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: '11111111-2222-3333-4444-555555555555',
+        id: uuid(),
+        slug: 'price',
         valueType: 'number',
         fieldType: 'number',
         label: { en: 'Price' },
@@ -50,14 +53,15 @@ describe('buildEntryValuesSchema', () => {
     ];
 
     const schema = buildEntryValuesSchema(fieldDefs);
-    const valid = { '11111111-2222-3333-4444-555555555555': { en: 50 } };
+    const valid = { price: { en: 50 } };
     expect(schema.parse(valid)).toEqual(valid);
   });
 
   it('rejects number outside of min/max range', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: '11111111-2222-3333-4444-555555555555',
+        id: uuid(),
+        slug: 'price',
         valueType: 'number',
         fieldType: 'number',
         label: { en: 'Price' },
@@ -73,15 +77,14 @@ describe('buildEntryValuesSchema', () => {
     ];
 
     const schema = buildEntryValuesSchema(fieldDefs);
-    expect(() =>
-      schema.parse({ '11111111-2222-3333-4444-555555555555': { en: 200 } })
-    ).toThrow();
+    expect(() => schema.parse({ price: { en: 200 } })).toThrow();
   });
 
   it('generates schema for a boolean (toggle) field definition', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: '22222222-3333-4444-5555-666666666666',
+        id: uuid(),
+        slug: 'active',
         valueType: 'boolean',
         fieldType: 'toggle',
         label: { en: 'Active' },
@@ -95,14 +98,15 @@ describe('buildEntryValuesSchema', () => {
     ];
 
     const schema = buildEntryValuesSchema(fieldDefs);
-    const valid = { '22222222-3333-4444-5555-666666666666': { en: true } };
+    const valid = { active: { en: true } };
     expect(schema.parse(valid)).toEqual(valid);
   });
 
   it('rejects non-boolean for toggle field', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: '22222222-3333-4444-5555-666666666666',
+        id: uuid(),
+        slug: 'active',
         valueType: 'boolean',
         fieldType: 'toggle',
         label: { en: 'Active' },
@@ -118,7 +122,7 @@ describe('buildEntryValuesSchema', () => {
     const schema = buildEntryValuesSchema(fieldDefs);
     expect(() =>
       schema.parse({
-        '22222222-3333-4444-5555-666666666666': { en: 'not-boolean' },
+        active: { en: 'not-boolean' },
       })
     ).toThrow();
   });
@@ -126,7 +130,8 @@ describe('buildEntryValuesSchema', () => {
   it('generates schema for an asset reference field definition', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: '33333333-4444-5555-6666-777777777777',
+        id: uuid(),
+        slug: 'image',
         valueType: 'reference',
         fieldType: 'asset',
         label: { en: 'Image' },
@@ -142,7 +147,7 @@ describe('buildEntryValuesSchema', () => {
 
     const schema = buildEntryValuesSchema(fieldDefs);
     const valid = {
-      '33333333-4444-5555-6666-777777777777': {
+      image: {
         en: [
           { id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', objectType: 'asset' },
         ],
@@ -154,7 +159,8 @@ describe('buildEntryValuesSchema', () => {
   it('generates schema for multiple field definitions', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: 'aaaaaaaa-1111-1111-1111-111111111111',
+        id: uuid(),
+        slug: 'name',
         valueType: 'string',
         fieldType: 'text',
         label: { en: 'Name' },
@@ -168,7 +174,8 @@ describe('buildEntryValuesSchema', () => {
         defaultValue: null,
       },
       {
-        id: 'bbbbbbbb-2222-2222-2222-222222222222',
+        id: uuid(),
+        slug: 'published',
         valueType: 'boolean',
         fieldType: 'toggle',
         label: { en: 'Published' },
@@ -183,8 +190,8 @@ describe('buildEntryValuesSchema', () => {
 
     const schema = buildEntryValuesSchema(fieldDefs);
     const valid = {
-      'aaaaaaaa-1111-1111-1111-111111111111': { en: 'Test' },
-      'bbbbbbbb-2222-2222-2222-222222222222': { en: true },
+      name: { en: 'Test' },
+      published: { en: true },
     };
     expect(schema.parse(valid)).toEqual(valid);
   });
@@ -199,7 +206,8 @@ describe('z.toJSONSchema() compatibility', () => {
   it('produces valid JSON Schema for entry values schema', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        id: uuid(),
+        slug: 'title',
         valueType: 'string',
         fieldType: 'text',
         label: { en: 'Title' },
@@ -213,7 +221,8 @@ describe('z.toJSONSchema() compatibility', () => {
         defaultValue: null,
       },
       {
-        id: '11111111-2222-3333-4444-555555555555',
+        id: uuid(),
+        slug: 'count',
         valueType: 'number',
         fieldType: 'number',
         label: { en: 'Count' },
@@ -233,12 +242,8 @@ describe('z.toJSONSchema() compatibility', () => {
 
     expect(jsonSchema).toBeDefined();
     expect(jsonSchema.type).toBe('object');
-    expect(jsonSchema.properties).toHaveProperty(
-      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
-    );
-    expect(jsonSchema.properties).toHaveProperty(
-      '11111111-2222-3333-4444-555555555555'
-    );
+    expect(jsonSchema.properties).toHaveProperty('title');
+    expect(jsonSchema.properties).toHaveProperty('count');
   });
 
   it('produces valid JSON Schema for assetSchema with .openapi() metadata', () => {
@@ -266,7 +271,8 @@ describe('buildEntryValuesTypeString', () => {
   it('generates TypeScript type string for field definitions', () => {
     const fieldDefs: FieldDefinition[] = [
       {
-        id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        id: uuid(),
+        slug: 'title',
         valueType: 'string',
         fieldType: 'text',
         label: { en: 'Title' },
@@ -280,7 +286,8 @@ describe('buildEntryValuesTypeString', () => {
         defaultValue: null,
       },
       {
-        id: '11111111-2222-3333-4444-555555555555',
+        id: uuid(),
+        slug: 'count',
         valueType: 'number',
         fieldType: 'number',
         label: { en: 'Count' },
@@ -294,7 +301,8 @@ describe('buildEntryValuesTypeString', () => {
         defaultValue: null,
       },
       {
-        id: '22222222-3333-4444-5555-666666666666',
+        id: uuid(),
+        slug: 'active',
         valueType: 'boolean',
         fieldType: 'toggle',
         label: { en: 'Active' },
@@ -306,7 +314,8 @@ describe('buildEntryValuesTypeString', () => {
         defaultValue: false,
       },
       {
-        id: '33333333-4444-5555-6666-777777777777',
+        id: uuid(),
+        slug: 'image',
         valueType: 'reference',
         fieldType: 'asset',
         label: { en: 'Image' },
@@ -323,10 +332,10 @@ describe('buildEntryValuesTypeString', () => {
     const types = buildEntryValuesTypeString(fieldDefs);
 
     expect(types).toContain('export type Entry');
-    expect(types).toContain('"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"');
-    expect(types).toContain('"11111111-2222-3333-4444-555555555555"');
-    expect(types).toContain('"22222222-3333-4444-5555-666666666666"');
-    expect(types).toContain('"33333333-4444-5555-6666-777777777777"');
+    expect(types).toContain('"title"');
+    expect(types).toContain('"count"');
+    expect(types).toContain('"active"');
+    expect(types).toContain('"image"');
     expect(types).toContain('string');
     expect(types).toContain('number');
     expect(types).toContain('boolean');

--- a/src/astro/schema.test.ts
+++ b/src/astro/schema.test.ts
@@ -255,7 +255,6 @@ describe('z.toJSONSchema() compatibility', () => {
     expect(properties).toHaveProperty('id');
     expect(properties).toHaveProperty('extension');
     expect(properties).toHaveProperty('absolutePath');
-    expect(properties).toHaveProperty('history');
   });
 
   it('produces valid JSON Schema for empty entry values schema', () => {

--- a/src/astro/schema.ts
+++ b/src/astro/schema.ts
@@ -6,7 +6,7 @@ import {
   getTranslatableReferenceValueContentSchemaFromFieldDefinition,
   getTranslatableStringValueContentSchemaFromFieldDefinition,
 } from '../schema/schemaFromFieldDefinition.js';
-import { ValueTypeSchema } from '../schema/valueSchema.js';
+import { valueTypeSchema } from '../schema/valueSchema.js';
 
 /**
  * Generates a flat Zod object schema from collection field definitions
@@ -20,19 +20,19 @@ export function buildEntryValuesSchema(fieldDefinitions: FieldDefinition[]) {
 
   for (const fieldDef of fieldDefinitions) {
     switch (fieldDef.valueType) {
-      case ValueTypeSchema.enum.string:
+      case valueTypeSchema.enum.string:
         shape[fieldDef.slug] =
           getTranslatableStringValueContentSchemaFromFieldDefinition(fieldDef);
         break;
-      case ValueTypeSchema.enum.number:
+      case valueTypeSchema.enum.number:
         shape[fieldDef.slug] =
           getTranslatableNumberValueContentSchemaFromFieldDefinition(fieldDef);
         break;
-      case ValueTypeSchema.enum.boolean:
+      case valueTypeSchema.enum.boolean:
         shape[fieldDef.slug] =
           getTranslatableBooleanValueContentSchemaFromFieldDefinition();
         break;
-      case ValueTypeSchema.enum.reference:
+      case valueTypeSchema.enum.reference:
         shape[fieldDef.slug] =
           getTranslatableReferenceValueContentSchemaFromFieldDefinition(
             fieldDef

--- a/src/astro/schema.ts
+++ b/src/astro/schema.ts
@@ -12,7 +12,7 @@ import { ValueTypeSchema } from '../schema/valueSchema.js';
  * Generates a flat Zod object schema from collection field definitions
  * for use with Astro's `parseData` validation.
  *
- * Each key is the field definition ID (UUID) and each value schema
+ * Each key is the field definition slug and each value schema
  * is the translatable content schema for that field type.
  */
 export function buildEntryValuesSchema(fieldDefinitions: FieldDefinition[]) {
@@ -21,19 +21,19 @@ export function buildEntryValuesSchema(fieldDefinitions: FieldDefinition[]) {
   for (const fieldDef of fieldDefinitions) {
     switch (fieldDef.valueType) {
       case ValueTypeSchema.enum.string:
-        shape[fieldDef.id] =
+        shape[fieldDef.slug] =
           getTranslatableStringValueContentSchemaFromFieldDefinition(fieldDef);
         break;
       case ValueTypeSchema.enum.number:
-        shape[fieldDef.id] =
+        shape[fieldDef.slug] =
           getTranslatableNumberValueContentSchemaFromFieldDefinition(fieldDef);
         break;
       case ValueTypeSchema.enum.boolean:
-        shape[fieldDef.id] =
+        shape[fieldDef.slug] =
           getTranslatableBooleanValueContentSchemaFromFieldDefinition();
         break;
       case ValueTypeSchema.enum.reference:
-        shape[fieldDef.id] =
+        shape[fieldDef.slug] =
           getTranslatableReferenceValueContentSchemaFromFieldDefinition(
             fieldDef
           );
@@ -60,7 +60,7 @@ export function buildEntryValuesTypeString(
 
   const fields = fieldDefinitions.map((fieldDef) => {
     const tsType = valueTypeToTsType(fieldDef.valueType);
-    return `  "${fieldDef.id}": Partial<Record<SupportedLanguage, ${tsType}>>`;
+    return `  "${fieldDef.slug}": Partial<Record<SupportedLanguage, ${tsType}>>`;
   });
 
   return [

--- a/src/astro/transform.test.ts
+++ b/src/astro/transform.test.ts
@@ -3,75 +3,71 @@ import type { Value } from '../schema/valueSchema.js';
 import { transformEntryValues } from './transform.js';
 
 describe('transformEntryValues', () => {
-  it('transforms string values keyed by field definition ID', () => {
-    const values: Value[] = [
-      {
+  it('transforms string values keyed by slug', () => {
+    const values: Record<string, Value> = {
+      title: {
         objectType: 'value',
         valueType: 'string',
-        fieldDefinitionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
         content: { en: 'Hello', de: 'Hallo' },
       },
-    ];
+    };
 
     const result = transformEntryValues(values);
 
     expect(result).toEqual({
-      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': { en: 'Hello', de: 'Hallo' },
+      title: { en: 'Hello', de: 'Hallo' },
     });
   });
 
   it('transforms number values', () => {
-    const values: Value[] = [
-      {
+    const values: Record<string, Value> = {
+      count: {
         objectType: 'value',
         valueType: 'number',
-        fieldDefinitionId: '11111111-2222-3333-4444-555555555555',
         content: { en: 42, de: 42 },
       },
-    ];
+    };
 
     const result = transformEntryValues(values);
 
     expect(result).toEqual({
-      '11111111-2222-3333-4444-555555555555': { en: 42, de: 42 },
+      count: { en: 42, de: 42 },
     });
   });
 
   it('transforms boolean values', () => {
-    const values: Value[] = [
-      {
+    const values: Record<string, Value> = {
+      active: {
         objectType: 'value',
         valueType: 'boolean',
-        fieldDefinitionId: '22222222-3333-4444-5555-666666666666',
         content: { en: true },
       },
-    ];
+    };
 
     const result = transformEntryValues(values);
 
     expect(result).toEqual({
-      '22222222-3333-4444-5555-666666666666': { en: true },
+      active: { en: true },
     });
   });
 
   it('transforms reference values', () => {
-    const values: Value[] = [
-      {
+    const values: Record<string, Value> = {
+      image: {
         objectType: 'value',
         valueType: 'reference',
-        fieldDefinitionId: '33333333-4444-5555-6666-777777777777',
         content: {
           en: [
             { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', objectType: 'asset' },
           ],
         },
       },
-    ];
+    };
 
     const result = transformEntryValues(values);
 
     expect(result).toEqual({
-      '33333333-4444-5555-6666-777777777777': {
+      image: {
         en: [
           { id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', objectType: 'asset' },
         ],
@@ -80,38 +76,35 @@ describe('transformEntryValues', () => {
   });
 
   it('transforms multiple values of different types', () => {
-    const values: Value[] = [
-      {
+    const values: Record<string, Value> = {
+      title: {
         objectType: 'value',
         valueType: 'string',
-        fieldDefinitionId: 'aaaaaaaa-1111-1111-1111-111111111111',
         content: { en: 'Title' },
       },
-      {
+      price: {
         objectType: 'value',
         valueType: 'number',
-        fieldDefinitionId: 'bbbbbbbb-2222-2222-2222-222222222222',
         content: { en: 99 },
       },
-      {
+      published: {
         objectType: 'value',
         valueType: 'boolean',
-        fieldDefinitionId: 'cccccccc-3333-3333-3333-333333333333',
         content: { en: false },
       },
-    ];
+    };
 
     const result = transformEntryValues(values);
 
     expect(result).toEqual({
-      'aaaaaaaa-1111-1111-1111-111111111111': { en: 'Title' },
-      'bbbbbbbb-2222-2222-2222-222222222222': { en: 99 },
-      'cccccccc-3333-3333-3333-333333333333': { en: false },
+      title: { en: 'Title' },
+      price: { en: 99 },
+      published: { en: false },
     });
   });
 
-  it('returns empty object for empty values array', () => {
-    const result = transformEntryValues([]);
+  it('returns empty object for empty values record', () => {
+    const result = transformEntryValues({});
     expect(result).toEqual({});
   });
 });

--- a/src/astro/transform.ts
+++ b/src/astro/transform.ts
@@ -1,14 +1,14 @@
 import type { Value } from '../schema/valueSchema.js';
 
 /**
- * Transforms an elek.io Entry's values array into a flat object
- * keyed by field definition ID. Each value's translatable content
+ * Transforms an elek.io Entry's values record into a flat object
+ * keyed by field definition slug. Each value's translatable content
  * is preserved as-is.
  */
-export function transformEntryValues(values: Value[]): Record<string, unknown> {
+export function transformEntryValues(values: Record<string, Value>) {
   const result: Record<string, unknown> = {};
-  for (const value of values) {
-    result[value.fieldDefinitionId] = value.content;
+  for (const [slug, value] of Object.entries(values)) {
+    result[slug] = value.content;
   }
   return result;
 }

--- a/src/cli/exportAction.ts
+++ b/src/cli/exportAction.ts
@@ -74,7 +74,7 @@ async function exportProjectNested({
 
     collectionContent = {
       ...collectionContent,
-      [collection.id]: { ...collection, entries: entryContent },
+      [collection.slug.plural]: { ...collection, entries: entryContent },
     };
   }
 

--- a/src/index.astro.test.ts
+++ b/src/index.astro.test.ts
@@ -63,7 +63,7 @@ export const collections = {
   entries: defineCollection({
     loader: elekEntries({
       projectId: '${project.id}',
-      collectionId: '${collection.id}',
+      collectionIdOrSlug: '${collection.id}',
     }),
   }),
 };

--- a/src/index.astro.ts
+++ b/src/index.astro.ts
@@ -15,7 +15,8 @@ interface ElekAssetsProps {
 
 interface ElekEntriesOptions {
   projectId: string;
-  collectionId: string;
+  /** Collection UUID or slug */
+  collectionIdOrSlug: string;
 }
 
 const core = new ElekIoCore({
@@ -116,9 +117,13 @@ export function elekEntries(props: ElekEntriesOptions): Loader {
   return {
     name: 'elek-entries',
     createSchema: async () => {
+      const resolvedId = await core.collections.resolveCollectionId({
+        projectId: props.projectId,
+        idOrSlug: props.collectionIdOrSlug,
+      });
       const collection = await core.collections.read({
         projectId: props.projectId,
-        id: props.collectionId,
+        id: resolvedId,
       });
 
       return {
@@ -127,14 +132,18 @@ export function elekEntries(props: ElekEntriesOptions): Loader {
       };
     },
     load: async (context) => {
+      const resolvedCollectionId = await core.collections.resolveCollectionId({
+        projectId: props.projectId,
+        idOrSlug: props.collectionIdOrSlug,
+      });
       context.logger.info(
-        `Loading elek.io Entries of Collection "${props.collectionId}" and Project "${props.projectId}"`
+        `Loading elek.io Entries of Collection "${props.collectionIdOrSlug}" and Project "${props.projectId}"`
       );
       context.store.clear();
 
       const { list: entries, total } = await core.entries.list({
         projectId: props.projectId,
-        collectionId: props.collectionId,
+        collectionId: resolvedCollectionId,
         limit: 0,
       });
       if (total === 0) {

--- a/src/index.cli.test.ts
+++ b/src/index.cli.test.ts
@@ -102,7 +102,9 @@ describe('CLI', function () {
     const projects = JSON.parse(projectsContent);
 
     expect(
-      projects[project1.id].collections[collection.id].entries[entry.id].id
+      projects[project1.id].collections[collection.slug.plural].entries[
+        entry.id
+      ].id
     ).toEqual(entry.id);
     expect(projects[project2.id].id).toEqual(project2.id);
   });
@@ -138,9 +140,9 @@ describe('CLI', function () {
     );
     const projects = JSON.parse(projectsContent);
 
-    expect(projects.collections[collection.id].entries[entry.id].id).toEqual(
-      entry.id
-    );
+    expect(
+      projects.collections[collection.slug.plural].entries[entry.id].id
+    ).toEqual(entry.id);
     expect(projects[project2.id]).toEqual(undefined);
   });
 

--- a/src/index.node.test.ts
+++ b/src/index.node.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { v4 as uuid } from 'uuid';
 import ElekIoCore from './index.node.js';
 import core from './test/setup.js';
 import Path from 'node:path';
@@ -98,7 +99,8 @@ describe('Node.js', function () {
         },
         fieldDefinitions: [
           {
-            id: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
+            id: uuid(),
+            slug: 'image',
             valueType: 'reference',
             fieldType: 'asset',
             label: {
@@ -117,7 +119,8 @@ describe('Node.js', function () {
             max: 1,
           },
           {
-            id: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
+            id: uuid(),
+            slug: 'keyword',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -137,7 +140,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: '10f10290-9043-4bab-bf6f-014ee81d41a4',
+            id: uuid(),
+            slug: 'name',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -157,7 +161,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
+            id: uuid(),
+            slug: 'description',
             valueType: 'string',
             fieldType: 'textarea',
             label: {
@@ -177,7 +182,8 @@ describe('Node.js', function () {
             max: 250,
           },
           {
-            id: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
+            id: uuid(),
+            slug: 'read-more-link',
             valueType: 'reference',
             fieldType: 'entry',
             ofCollections: [],
@@ -202,11 +208,10 @@ describe('Node.js', function () {
       const featureEntryProjects = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -222,53 +227,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Projects',
               de: 'Projekte',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Organise Content in Projects',
               de: 'Organisiere Inhalte in Projekten',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Create Projects to organise your content. Each Project contains its own Collections, Assets, and settings.',
               de: 'Erstelle Projekte, um deine Inhalte zu organisieren. Jedes Projekt enthält eigene Sammlungen, Assets und Einstellungen.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryAssets = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -284,53 +284,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Assets',
               de: 'Assets',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Add Images, Documents & More as Assets',
               de: 'Füge Bilder, Dokumente und mehr als Assets hinzu',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Add various types of assets such as images, documents, and more to your Projects. Manage all your media and files in one place.',
               de: 'Füge verschiedene Arten von Assets wie Bilder, Dokumente und mehr zu deinen Projekten hinzu. Verwalte alle deine Medien und Dateien an einem Ort.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryCollections = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -346,53 +341,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Collections',
               de: 'Sammlungen',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Create Collections of Content',
               de: 'Erstelle Sammlungen von Inhalten',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Create Collections to organise content that has the same structure. Use field definitions to define the structure, helpful hints and validation rules for your content.',
               de: 'Erstelle Sammlungen, um Inhalte mit derselben Struktur zu organisieren. Verwende Felddefinitionen, um die Struktur, hilfreiche Hinweise und Validierungsregeln für deine Inhalte festzulegen.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryEntries = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -408,53 +398,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Entries',
               de: 'Einträge',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Managing Entries',
               de: 'Verwalten von Einträgen',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Add Entries to your Collections to populate them with content. Each Entry represents a piece of content that can be created, updated and deleted.',
               de: 'Füge Einträge zu deinen Sammlungen hinzu, um sie mit Inhalten zu füllen. Jeder Eintrag stellt ein Stück Inhalt dar, das erstellt, aktualisiert und gelöscht werden kann.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryHistory = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -470,53 +455,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'History',
               de: 'Versionshistorie',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Go Back in Time to Previous Versions',
               de: 'Reise zurück in der Zeit zu vorherigen Versionen',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Keep track of all changes made to your content with version history. Easily revert to previous versions whenever needed.',
               de: 'Behalte alle Änderungen an deinen Inhalten mit der Versionshistorie im Blick. Stelle bei Bedarf problemlos frühere Versionen wieder her.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryTeamwork = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -532,53 +512,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Teamwork',
               de: 'Teamarbeit',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Collaborate with your team seamlessly',
               de: 'Nahtlose Zusammenarbeit mit deinem Team',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
-              en: 'Work together by syncing content changes using any Git provider like GitHub, GitLab, Bitbucket and more. Get things done even when offline and synchronize changes when you’re back online.',
+              en: "Work together by syncing content changes using any Git provider like GitHub, GitLab, Bitbucket and more. Get things done even when offline and synchronize changes when you're back online.",
               de: 'Arbeite zusammen, indem du Inhaltsänderungen mit jedem Git-Anbieter wie GitHub, GitLab, Bitbucket und mehr synchronisierst. Erledige Aufgaben auch offline und synchronisiere Änderungen, wenn du wieder online bist.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryIntegrate = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -594,53 +569,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Integrate',
               de: 'Integrieren',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Use your Content wherever you want',
               de: 'Verwende deine Inhalte, wo immer du möchtest',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Use elek.io Desktop or Core with any framework of your choice. Integrate it into the build process of your website, app and deploy your content anywhere.',
               de: 'Verwende elek.io Desktop oder Core mit einem Framework deiner Wahl. Integriere es in den Build-Prozess deiner Website, App und deploye deine Inhalte überall.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryInstant = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -656,53 +626,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Instant',
               de: 'Sofort',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Instant content updates without redeployment',
               de: 'Sofortige Inhaltsaktualisierungen ohne Redeployment',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Synchronize content updates to elek.io Cloud and have them instantly available worldwide without the need for redeployment of your website or app.',
               de: 'Synchronisiere Inhaltsaktualisierungen mit elek.io Cloud und habe sie sofort weltweit verfügbar, ohne dass deine Website oder App erneut deployed werden muss.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryReplication = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -718,53 +683,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Replication',
               de: 'Replikation',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Data replication in up to 14 geo-regions',
               de: 'Datenreplikation in bis zu 14 Geo-Regionen',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'We ensure low-latency access to your content by replicating data across multiple geo-regions. elek.io Cloud automatically routes requests to the nearest region for optimal performance.',
               de: 'Wir sorgen für einen latenzarmen Zugriff auf deine Inhalte, indem wir Daten über mehrere Geo-Regionen replizieren. elek.io Cloud leitet Anfragen automatisch an die nächstgelegene Region für optimale Leistung weiter.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryAutomation = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -780,53 +740,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Automation',
               de: 'Automatisierung',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Automate workflows with webhooks and integrations',
               de: 'Automatisiere Workflows mit Webhooks und Integrationen',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Set up webhooks to trigger automated workflows whenever your content changes. Integrate with third-party services or your own backend to keep everything in sync.',
               de: 'Richte Webhooks ein, um automatisierte Workflows auszulösen, sobald sich deine Inhalte ändern. Integriere Drittanbieterdienste oder dein eigenes Backend, um alles synchron zu halten.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryCode = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -842,53 +797,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Code',
               de: 'Code',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Manage your content with code',
               de: 'Verwalte deine Inhalte mit Code',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Manage content programmatically by using elek.io Core directly within your JavaScript / TypeScript codebase. Create Projects, add Collections and Entries and more.',
               de: 'Verwalte Inhalte programmatisch, indem du elek.io Core direkt in deinem JavaScript- / TypeScript-Code verwendest. Erstelle Projekte, füge Sammlungen und Einträge hinzu und mehr.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryApiClients = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -904,53 +854,48 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'API Clients',
               de: 'API Clients',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Generate API Clients',
               de: 'Generiere API-Clients',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Create typesafe API Clients for your Projects in JavaScript or TypeScript to dynamically read your content locally and remotely via Cloud.',
               de: 'Erstelle typsichere API-Clients für deine Projekte in JavaScript oder TypeScript, um deine Inhalte lokal und remote über die Cloud dynamisch zu lesen.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       const featureEntryExport = await core.entries.create({
         projectId: project.id,
         collectionId: featuresCollection.id,
-        values: [
-          {
+        values: {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '737651a5-ad70-4bbf-b6ad-cb9b8af88bc5',
             content: {
               en: [
                 {
@@ -966,43 +911,39 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          keyword: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '52daf10c-9ea8-4b84-98f9-d84b4ba4c134',
             content: {
               en: 'Export',
               de: 'Exportieren',
             },
           },
-          {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '10f10290-9043-4bab-bf6f-014ee81d41a4',
             content: {
               en: 'Export your content into JSON files',
               de: 'Exportiere deine Inhalte in JSON-Dateien',
             },
           },
-          {
+          description: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '405e2cb0-23c0-4bce-89cd-334acd95dbd0',
             content: {
               en: 'Export your content into JSON files to use them statically or easily integrate with other tools and workflows. Watch mode allows for automatic exports whenever content changes.',
               de: 'Exportiere deine Inhalte in JSON-Dateien, um sie statisch zu verwenden oder einfach mit anderen Tools und Workflows zu integrieren. Der Watch-Modus ermöglicht automatische Exporte, sobald sich Inhalte ändern.',
             },
           },
-          {
+          'read-more-link': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '7cfbd197-f949-4f5a-b71c-5f5c77653df8',
             content: {
               en: [],
               de: [],
             },
           },
-        ],
+        },
       });
 
       /**
@@ -1032,7 +973,8 @@ describe('Node.js', function () {
         },
         fieldDefinitions: [
           {
-            id: '559cda05-91a5-40d2-8113-fb0267e320f4',
+            id: uuid(),
+            slug: 'name',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1052,7 +994,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: 'bec97b46-710e-4d9c-bc73-51af731e727f',
+            id: uuid(),
+            slug: 'slug',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1072,7 +1015,8 @@ describe('Node.js', function () {
             max: null,
           },
           {
-            id: '8b8bca59-8cc7-4357-8984-b5a2caf21020',
+            id: uuid(),
+            slug: 'tagline',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1092,7 +1036,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: 'b025e42e-ff64-40dd-8fbf-d41f7c9ae5fa',
+            id: uuid(),
+            slug: 'short-description',
             valueType: 'string',
             fieldType: 'textarea',
             label: {
@@ -1112,7 +1057,8 @@ describe('Node.js', function () {
             max: 165,
           },
           {
-            id: '8bc0a027-5448-4a9c-8b04-4c6141bc29f5',
+            id: uuid(),
+            slug: 'image',
             valueType: 'reference',
             fieldType: 'asset',
             label: {
@@ -1131,7 +1077,8 @@ describe('Node.js', function () {
             max: 1,
           },
           {
-            id: '83830be8-c372-44bf-a1b4-83d83e0babe9',
+            id: uuid(),
+            slug: 'feature-description',
             valueType: 'string',
             fieldType: 'textarea',
             label: {
@@ -1151,7 +1098,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: 'd106e37c-e6e3-4039-92f5-365163ecdd3c',
+            id: uuid(),
+            slug: 'features',
             valueType: 'reference',
             fieldType: 'entry',
             ofCollections: [featuresCollection.id],
@@ -1176,47 +1124,42 @@ describe('Node.js', function () {
       const productEntryDesktop = await core.entries.create({
         projectId: project.id,
         collectionId: productsCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '559cda05-91a5-40d2-8113-fb0267e320f4',
             content: {
               en: 'elek.io Desktop',
               de: 'elek.io Desktop',
             },
           },
-          {
+          slug: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'bec97b46-710e-4d9c-bc73-51af731e727f',
             content: {
               en: 'desktop',
               de: 'desktop',
             },
           },
-          {
+          tagline: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '8b8bca59-8cc7-4357-8984-b5a2caf21020',
             content: {
               en: 'The offline-first CMS',
               de: 'Das Offline-First-CMS',
             },
           },
-          {
+          'short-description': {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'b025e42e-ff64-40dd-8fbf-d41f7c9ae5fa',
             content: {
               en: "Manage your content locally, even when you're offline - no server needed. Sync changes when you're back online.",
               de: 'Verwalte deine Inhalte lokal, auch wenn du offline bist - kein Server erforderlich. Synchronisiere Änderungen, wenn du wieder online bist.',
             },
           },
-          {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '8bc0a027-5448-4a9c-8b04-4c6141bc29f5',
             content: {
               en: [
                 {
@@ -1232,19 +1175,17 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          'feature-description': {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '83830be8-c372-44bf-a1b4-83d83e0babe9',
             content: {
               en: 'Too long',
               de: 'Zu lang',
             },
           },
-          {
+          features: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: 'd106e37c-e6e3-4039-92f5-365163ecdd3c',
             content: {
               en: [
                 {
@@ -1308,53 +1249,48 @@ describe('Node.js', function () {
               ],
             },
           },
-        ],
+        },
       });
 
       const productEntryCloud = await core.entries.create({
         projectId: project.id,
         collectionId: productsCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '559cda05-91a5-40d2-8113-fb0267e320f4',
             content: {
               en: 'elek.io Cloud',
               de: 'elek.io Cloud',
             },
           },
-          {
+          slug: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'bec97b46-710e-4d9c-bc73-51af731e727f',
             content: {
               en: 'cloud',
               de: 'cloud',
             },
           },
-          {
+          tagline: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '8b8bca59-8cc7-4357-8984-b5a2caf21020',
             content: {
               en: 'The Content Delivery API',
               de: 'Die Content Delivery API',
             },
           },
-          {
+          'short-description': {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'b025e42e-ff64-40dd-8fbf-d41f7c9ae5fa',
             content: {
               en: 'Host your content globally available with minimum latency. Connect APIs and webhooks easily with elek.io Cloud.',
               de: 'Mache deine Inhalte weltweit mit minimaler Latenz verfügbar. Verbinde APIs und Webhooks einfach mit elek.io Cloud.',
             },
           },
-          {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '8bc0a027-5448-4a9c-8b04-4c6141bc29f5',
             content: {
               en: [
                 {
@@ -1370,19 +1306,17 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          'feature-description': {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '83830be8-c372-44bf-a1b4-83d83e0babe9',
             content: {
               en: 'elek.io Cloud is a globally distributed content delivery API that ensures your content is always available with minimal latency, no matter where your users are located.',
               de: 'elek.io Cloud ist eine global verteilte Content Delivery API, die sicherstellt, dass deine Inhalte immer mit minimaler Latenz verfügbar sind, egal wo sich deine Nutzer befinden.',
             },
           },
-          {
+          features: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: 'd106e37c-e6e3-4039-92f5-365163ecdd3c',
             content: {
               en: [
                 {
@@ -1414,53 +1348,48 @@ describe('Node.js', function () {
               ],
             },
           },
-        ],
+        },
       });
 
       const productEntryCore = await core.entries.create({
         projectId: project.id,
         collectionId: productsCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '559cda05-91a5-40d2-8113-fb0267e320f4',
             content: {
               en: 'elek.io Core',
               de: 'elek.io Core',
             },
           },
-          {
+          slug: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'bec97b46-710e-4d9c-bc73-51af731e727f',
             content: {
               en: 'core',
               de: 'core',
             },
           },
-          {
+          tagline: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '8b8bca59-8cc7-4357-8984-b5a2caf21020',
             content: {
               en: 'Generate API Clients and export content',
               de: 'Generiere API-Clients und exportiere Inhalte',
             },
           },
-          {
+          'short-description': {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'b025e42e-ff64-40dd-8fbf-d41f7c9ae5fa',
             content: {
               en: 'Programmatically manage your content, generate JavaScript / TypeScript API Clients and use our CLI tool to export content.',
               de: 'Verwalte deine Inhalte programmgesteuert, generiere JavaScript / TypeScript API-Clients und verwende unser CLI-Tool, um Inhalte zu exportieren.',
             },
           },
-          {
+          image: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '8bc0a027-5448-4a9c-8b04-4c6141bc29f5',
             content: {
               en: [
                 {
@@ -1476,19 +1405,17 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          'feature-description': {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '83830be8-c372-44bf-a1b4-83d83e0babe9',
             content: {
               en: 'elek.io Core additionally to using the build in API of elek.io Desktop, gives you multiple other ways to interact with your content.',
               de: 'elek.io Core zusätzlich zur Verwendung der integrierten API von elek.io Desktop bietet dir mehrere andere Möglichkeiten, mit deinen Inhalten zu interagieren.',
             },
           },
-          {
+          features: {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: 'd106e37c-e6e3-4039-92f5-365163ecdd3c',
             content: {
               en: [
                 {
@@ -1520,7 +1447,7 @@ describe('Node.js', function () {
               ],
             },
           },
-        ],
+        },
       });
 
       /**
@@ -1550,7 +1477,8 @@ describe('Node.js', function () {
         },
         fieldDefinitions: [
           {
-            id: 'd1686a8e-5761-42e0-9801-47d3bcd9e682',
+            id: uuid(),
+            slug: 'name',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1570,7 +1498,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: '8336f242-2136-47a6-9e40-05d08283c026',
+            id: uuid(),
+            slug: 'external-link',
             valueType: 'boolean',
             fieldType: 'toggle',
             label: {
@@ -1588,7 +1517,8 @@ describe('Node.js', function () {
             defaultValue: false,
           },
           {
-            id: '378b11d0-4e05-4612-99ba-7660a29fa417',
+            id: uuid(),
+            slug: 'target-page',
             valueType: 'reference',
             fieldType: 'entry',
             ofCollections: [productsCollection.id],
@@ -1608,7 +1538,8 @@ describe('Node.js', function () {
             max: 1,
           },
           {
-            id: 'd58284e5-8a75-4bea-9f54-51eda6600794',
+            id: uuid(),
+            slug: 'url',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1633,29 +1564,26 @@ describe('Node.js', function () {
       const navigationItemEntryDesktop = await core.entries.create({
         projectId: project.id,
         collectionId: navigationItemCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'd1686a8e-5761-42e0-9801-47d3bcd9e682',
             content: {
               en: 'elek.io Desktop',
               de: 'elek.io Desktop',
             },
           },
-          {
+          'external-link': {
             objectType: 'value',
             valueType: 'boolean',
-            fieldDefinitionId: '8336f242-2136-47a6-9e40-05d08283c026',
             content: {
               en: false,
               de: false,
             },
           },
-          {
+          'target-page': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '378b11d0-4e05-4612-99ba-7660a29fa417',
             content: {
               en: [
                 {
@@ -1671,41 +1599,37 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          url: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'd58284e5-8a75-4bea-9f54-51eda6600794',
             content: {},
           },
-        ],
+        },
       });
 
       const navigationItemEntryCloud = await core.entries.create({
         projectId: project.id,
         collectionId: navigationItemCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'd1686a8e-5761-42e0-9801-47d3bcd9e682',
             content: {
               en: 'elek.io Cloud',
               de: 'elek.io Cloud',
             },
           },
-          {
+          'external-link': {
             objectType: 'value',
             valueType: 'boolean',
-            fieldDefinitionId: '8336f242-2136-47a6-9e40-05d08283c026',
             content: {
               en: false,
               de: false,
             },
           },
-          {
+          'target-page': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '378b11d0-4e05-4612-99ba-7660a29fa417',
             content: {
               en: [
                 {
@@ -1721,41 +1645,37 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          url: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'd58284e5-8a75-4bea-9f54-51eda6600794',
             content: {},
           },
-        ],
+        },
       });
 
       const navigationItemEntryCore = await core.entries.create({
         projectId: project.id,
         collectionId: navigationItemCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'd1686a8e-5761-42e0-9801-47d3bcd9e682',
             content: {
               en: 'elek.io Core',
               de: 'elek.io Core',
             },
           },
-          {
+          'external-link': {
             objectType: 'value',
             valueType: 'boolean',
-            fieldDefinitionId: '8336f242-2136-47a6-9e40-05d08283c026',
             content: {
               en: false,
               de: false,
             },
           },
-          {
+          'target-page': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '378b11d0-4e05-4612-99ba-7660a29fa417',
             content: {
               en: [
                 {
@@ -1771,13 +1691,12 @@ describe('Node.js', function () {
               ],
             },
           },
-          {
+          url: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: 'd58284e5-8a75-4bea-9f54-51eda6600794',
             content: {},
           },
-        ],
+        },
       });
 
       /**
@@ -1809,7 +1728,8 @@ describe('Node.js', function () {
         },
         fieldDefinitions: [
           {
-            id: '8f3fa878-d137-42da-b353-714d3d01b83a',
+            id: uuid(),
+            slug: 'name',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1829,7 +1749,8 @@ describe('Node.js', function () {
             defaultValue: null,
           },
           {
-            id: '64948570-104f-441b-9e25-f006e1eae9d1',
+            id: uuid(),
+            slug: 'slug',
             valueType: 'string',
             fieldType: 'text',
             label: {
@@ -1849,7 +1770,8 @@ describe('Node.js', function () {
             max: null,
           },
           {
-            id: '9d0f1c02-5855-4a5e-8190-58000d2bdee6',
+            id: uuid(),
+            slug: 'navigation-items',
             valueType: 'reference',
             fieldType: 'entry',
             ofCollections: [navigationItemCollection.id],
@@ -1874,29 +1796,26 @@ describe('Node.js', function () {
       await core.entries.create({
         projectId: project.id,
         collectionId: navigationCollection.id,
-        values: [
-          {
+        values: {
+          name: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '8f3fa878-d137-42da-b353-714d3d01b83a',
             content: {
               en: 'Product Navigation',
               de: 'Produkt-Navigation',
             },
           },
-          {
+          slug: {
             objectType: 'value',
             valueType: 'string',
-            fieldDefinitionId: '64948570-104f-441b-9e25-f006e1eae9d1',
             content: {
               en: 'products',
               de: 'produkte',
             },
           },
-          {
+          'navigation-items': {
             objectType: 'value',
             valueType: 'reference',
-            fieldDefinitionId: '9d0f1c02-5855-4a5e-8190-58000d2bdee6',
             content: {
               en: [
                 {
@@ -1928,7 +1847,7 @@ describe('Node.js', function () {
               ],
             },
           },
-        ],
+        },
       });
 
       await core.projects.delete({ id: project.id, force: true });

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -100,7 +100,6 @@ export default class ElekIoCore {
       this.logService,
       this.gitService,
       this.jsonFileService,
-      this.collectionService,
       this.projectService
     );
     this.localApi = new LocalApi(

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -67,18 +67,21 @@ export default class ElekIoCore {
       this.userService
     );
     this.assetService = new AssetService(
+      this.coreVersion,
       this.options,
       this.logService,
       this.jsonFileService,
       this.gitService
     );
     this.collectionService = new CollectionService(
+      this.coreVersion,
       this.options,
       this.logService,
       this.jsonFileService,
       this.gitService
     );
     this.entryService = new EntryService(
+      this.coreVersion,
       this.options,
       this.logService,
       this.jsonFileService,

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -14,6 +14,7 @@ import {
   GitService,
   JsonFileService,
   ProjectService,
+  ReleaseService,
   UserService,
 } from './service/index.js';
 import { LogService } from './service/LogService.js';
@@ -40,6 +41,7 @@ export default class ElekIoCore {
   private readonly projectService: ProjectService;
   private readonly collectionService: CollectionService;
   private readonly entryService: EntryService;
+  private readonly releaseService: ReleaseService;
   private readonly localApi: LocalApi;
 
   constructor(props?: ConstructorElekIoCoreProps) {
@@ -92,6 +94,14 @@ export default class ElekIoCore {
       this.assetService,
       this.collectionService,
       this.entryService
+    );
+    this.releaseService = new ReleaseService(
+      this.options,
+      this.logService,
+      this.gitService,
+      this.jsonFileService,
+      this.collectionService,
+      this.projectService
     );
     this.localApi = new LocalApi(
       this.logService,
@@ -166,6 +176,13 @@ export default class ElekIoCore {
    */
   public get entries(): EntryService {
     return this.entryService;
+  }
+
+  /**
+   * Prepare and create releases
+   */
+  public get releases(): ReleaseService {
+    return this.releaseService;
   }
 
   /**

--- a/src/schema/assetSchema.ts
+++ b/src/schema/assetSchema.ts
@@ -1,7 +1,6 @@
 import { z } from '@hono/zod-openapi';
 import { objectTypeSchema, uuidSchema } from './baseSchema.js';
 import { baseFileSchema } from './fileSchema.js';
-import { gitCommitSchema } from './gitSchema.js';
 
 export const assetFileSchema = baseFileSchema.extend({
   objectType: z.literal(objectTypeSchema.enum.asset).readonly(),
@@ -22,13 +21,15 @@ export const assetSchema = assetFileSchema
      * Absolute path on this filesystem
      */
     absolutePath: z.string().readonly(),
-    /**
-     * Commit history of this Asset
-     */
-    history: z.array(gitCommitSchema),
   })
   .openapi('Asset');
 export type Asset = z.infer<typeof assetSchema>;
+
+export const assetHistorySchema = z.object({
+  id: uuidSchema.readonly(),
+  projectId: uuidSchema.readonly(),
+});
+export type AssetHistoryProps = z.infer<typeof assetHistorySchema>;
 
 export const assetExportSchema = assetSchema.extend({});
 export type AssetExport = z.infer<typeof assetExportSchema>;

--- a/src/schema/assetSchema.ts
+++ b/src/schema/assetSchema.ts
@@ -4,8 +4,8 @@ import { baseFileSchema } from './fileSchema.js';
 
 export const assetFileSchema = baseFileSchema.extend({
   objectType: z.literal(objectTypeSchema.enum.asset).readonly(),
-  name: z.string(),
-  description: z.string(),
+  name: z.string().trim().min(1),
+  description: z.string().trim().min(1),
   extension: z.string().readonly(),
   mimeType: z.string().readonly(),
   /**
@@ -93,6 +93,11 @@ export const deleteAssetSchema = assetFileSchema
     projectId: uuidSchema.readonly(),
   });
 export type DeleteAssetProps = z.infer<typeof deleteAssetSchema>;
+
+export const migrateAssetSchema = z.looseObject(
+  assetFileSchema.pick({ id: true, coreVersion: true }).shape
+);
+export type MigrateAssetProps = z.infer<typeof migrateAssetSchema>;
 
 export const countAssetsSchema = z.object({ projectId: uuidSchema.readonly() });
 export type CountAssetsProps = z.infer<typeof countAssetsSchema>;

--- a/src/schema/baseSchema.test.ts
+++ b/src/schema/baseSchema.test.ts
@@ -3,6 +3,8 @@ import {
   translatableStringSchema,
   translatableNumberSchema,
   translatableBooleanSchema,
+  slugSchema,
+  reservedSlugs,
 } from './baseSchema.js';
 
 describe('translatableStringSchema', () => {
@@ -77,5 +79,71 @@ describe('translatableBooleanSchema', () => {
     const result = translatableBooleanSchema.safeParse({ en: 'yes' });
 
     expect(result.success).toBe(false);
+  });
+});
+
+describe('slugSchema', () => {
+  it('accepts valid slugs', () => {
+    expect(slugSchema.safeParse('products').success).toBe(true);
+    expect(slugSchema.safeParse('my-products').success).toBe(true);
+    expect(slugSchema.safeParse('my-cool-products').success).toBe(true);
+    expect(slugSchema.safeParse('a').success).toBe(true);
+    expect(slugSchema.safeParse('a1b2').success).toBe(true);
+    expect(slugSchema.safeParse('123').success).toBe(true);
+    expect(slugSchema.safeParse('product-1').success).toBe(true);
+  });
+
+  it('rejects empty strings', () => {
+    expect(slugSchema.safeParse('').success).toBe(false);
+  });
+
+  it('rejects strings exceeding max length', () => {
+    const longSlug = 'a'.repeat(129);
+    expect(slugSchema.safeParse(longSlug).success).toBe(false);
+  });
+
+  it('accepts strings at max length', () => {
+    const maxSlug = 'a'.repeat(128);
+    expect(slugSchema.safeParse(maxSlug).success).toBe(true);
+  });
+
+  it('rejects uppercase characters', () => {
+    expect(slugSchema.safeParse('Products').success).toBe(false);
+    expect(slugSchema.safeParse('PRODUCTS').success).toBe(false);
+    expect(slugSchema.safeParse('myProducts').success).toBe(false);
+  });
+
+  it('rejects special characters', () => {
+    expect(slugSchema.safeParse('my_products').success).toBe(false);
+    expect(slugSchema.safeParse('my products').success).toBe(false);
+    expect(slugSchema.safeParse('my.products').success).toBe(false);
+    expect(slugSchema.safeParse('my/products').success).toBe(false);
+    expect(slugSchema.safeParse('@products').success).toBe(false);
+  });
+
+  it('rejects leading or trailing hyphens', () => {
+    expect(slugSchema.safeParse('-products').success).toBe(false);
+    expect(slugSchema.safeParse('products-').success).toBe(false);
+    expect(slugSchema.safeParse('-products-').success).toBe(false);
+  });
+
+  it('rejects consecutive hyphens', () => {
+    expect(slugSchema.safeParse('my--products').success).toBe(false);
+  });
+
+  it('rejects all reserved slugs', () => {
+    for (const reserved of reservedSlugs) {
+      expect(
+        slugSchema.safeParse(reserved).success,
+        `Expected reserved slug "${reserved}" to be rejected`
+      ).toBe(false);
+    }
+  });
+
+  it('rejects non-string values', () => {
+    expect(slugSchema.safeParse(123).success).toBe(false);
+    expect(slugSchema.safeParse(null).success).toBe(false);
+    expect(slugSchema.safeParse(undefined).success).toBe(false);
+    expect(slugSchema.safeParse({}).success).toBe(false);
   });
 });

--- a/src/schema/baseSchema.ts
+++ b/src/schema/baseSchema.ts
@@ -42,7 +42,7 @@ export const supportedLanguageSchema = z.enum([
 ]);
 export type SupportedLanguage = z.infer<typeof supportedLanguageSchema>;
 
-export const supportedIconSchema = z.enum(['home', 'plus', 'foobar']);
+export const supportedIconSchema = z.enum(['home', 'plus']);
 export type SupportedIcon = z.infer<typeof supportedIconSchema>;
 
 export const objectTypeSchema = z.enum([
@@ -57,13 +57,10 @@ export type ObjectType = z.infer<typeof objectTypeSchema>;
 
 export const logLevelSchema = z.enum(['error', 'warn', 'info', 'debug']);
 
-export const versionSchema = z.string();
-// .refine((version) => {
-//   if (Semver.valid(version) !== null) {
-//     return true;
-//   }
-//   return false;
-// }, 'String must follow the Semantic Versioning format (https://semver.org/)');
+export const versionSchema = z.string().refine(
+  (version) => /^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/.test(version),
+  'String must follow the Semantic Versioning format (https://semver.org/)'
+);
 export type Version = z.infer<typeof versionSchema>;
 
 export const uuidSchema = z.uuid();

--- a/src/schema/baseSchema.ts
+++ b/src/schema/baseSchema.ts
@@ -57,10 +57,12 @@ export type ObjectType = z.infer<typeof objectTypeSchema>;
 
 export const logLevelSchema = z.enum(['error', 'warn', 'info', 'debug']);
 
-export const versionSchema = z.string().refine(
-  (version) => /^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/.test(version),
-  'String must follow the Semantic Versioning format (https://semver.org/)'
-);
+export const versionSchema = z
+  .string()
+  .refine(
+    (version) => /^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/.test(version),
+    'String must follow the Semantic Versioning format (https://semver.org/)'
+  );
 export type Version = z.infer<typeof versionSchema>;
 
 export const uuidSchema = z.uuid();

--- a/src/schema/baseSchema.ts
+++ b/src/schema/baseSchema.ts
@@ -99,3 +99,47 @@ export type TranslatableBoolean = z.infer<typeof translatableBooleanSchema>;
 export function translatableArrayOf<T extends z.ZodTypeAny>(schema: T) {
   return z.partialRecord(supportedLanguageSchema, z.array(schema));
 }
+
+export const reservedSlugs = new Set([
+  'index',
+  'new',
+  'create',
+  'update',
+  'delete',
+  'edit',
+  'list',
+  'count',
+  'api',
+  'admin',
+  'collection',
+  'collections',
+  'entry',
+  'entries',
+  'asset',
+  'assets',
+  'project',
+  'projects',
+  'null',
+  'undefined',
+  'true',
+  'false',
+  'constructor',
+  '__proto__',
+  'prototype',
+  'toString',
+  'valueOf',
+  'login',
+  'logout',
+  'auth',
+  'settings',
+  'config',
+]);
+
+export const slugSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  .refine((slug) => !reservedSlugs.has(slug), {
+    message: 'This slug is reserved and cannot be used',
+  });

--- a/src/schema/collectionSchema.ts
+++ b/src/schema/collectionSchema.ts
@@ -9,7 +9,6 @@ import {
 import { entryExportSchema } from './entrySchema.js';
 import { fieldDefinitionSchema } from './fieldSchema.js';
 import { baseFileSchema } from './fileSchema.js';
-import { gitCommitSchema } from './gitSchema.js';
 
 export const collectionFileSchema = baseFileSchema.extend({
   objectType: z.literal(objectTypeSchema.enum.collection).readonly(),
@@ -27,15 +26,14 @@ export const collectionFileSchema = baseFileSchema.extend({
 });
 export type CollectionFile = z.infer<typeof collectionFileSchema>;
 
-export const collectionSchema = collectionFileSchema
-  .extend({
-    /**
-     * Commit history of this Collection
-     */
-    history: z.array(gitCommitSchema),
-  })
-  .openapi('Collection');
+export const collectionSchema = collectionFileSchema.openapi('Collection');
 export type Collection = z.infer<typeof collectionSchema>;
+
+export const collectionHistorySchema = z.object({
+  id: uuidSchema.readonly(),
+  projectId: uuidSchema.readonly(),
+});
+export type CollectionHistoryProps = z.infer<typeof collectionHistorySchema>;
 
 export const collectionExportSchema = collectionSchema.extend({
   entries: z.array(entryExportSchema),

--- a/src/schema/collectionSchema.ts
+++ b/src/schema/collectionSchema.ts
@@ -17,8 +17,8 @@ export const collectionFileSchema = baseFileSchema.extend({
     plural: translatableStringSchema,
   }),
   slug: z.object({
-    singular: z.string(),
-    plural: z.string(),
+    singular: slugSchema,
+    plural: slugSchema,
   }),
   description: translatableStringSchema,
   icon: supportedIconSchema,
@@ -44,6 +44,7 @@ export const createCollectionSchema = collectionFileSchema
   .omit({
     id: true,
     objectType: true,
+    coreVersion: true,
     created: true,
     updated: true,
   })
@@ -89,6 +90,11 @@ export const countCollectionsSchema = z.object({
   projectId: uuidSchema.readonly(),
 });
 export type CountCollectionsProps = z.infer<typeof countCollectionsSchema>;
+
+export const migrateCollectionSchema = z.looseObject(
+  collectionFileSchema.pick({ id: true, coreVersion: true }).shape
+);
+export type MigrateCollectionProps = z.infer<typeof migrateCollectionSchema>;
 
 export const resolveCollectionIdSchema = z.object({
   projectId: uuidSchema.readonly(),

--- a/src/schema/collectionSchema.ts
+++ b/src/schema/collectionSchema.ts
@@ -1,6 +1,7 @@
 import { z } from '@hono/zod-openapi';
 import {
   objectTypeSchema,
+  slugSchema,
   supportedIconSchema,
   translatableStringSchema,
   uuidSchema,
@@ -60,6 +61,15 @@ export const readCollectionSchema = z.object({
 });
 export type ReadCollectionProps = z.infer<typeof readCollectionSchema>;
 
+export const readBySlugCollectionSchema = z.object({
+  slug: slugSchema,
+  projectId: uuidSchema.readonly(),
+  commitHash: z.string().optional().readonly(),
+});
+export type ReadBySlugCollectionProps = z.infer<
+  typeof readBySlugCollectionSchema
+>;
+
 export const updateCollectionSchema = collectionFileSchema
   .pick({
     id: true,
@@ -81,3 +91,11 @@ export const countCollectionsSchema = z.object({
   projectId: uuidSchema.readonly(),
 });
 export type CountCollectionsProps = z.infer<typeof countCollectionsSchema>;
+
+export const resolveCollectionIdSchema = z.object({
+  projectId: uuidSchema.readonly(),
+  idOrSlug: z.string(),
+});
+export type ResolveCollectionIdProps = z.infer<
+  typeof resolveCollectionIdSchema
+>;

--- a/src/schema/entrySchema.ts
+++ b/src/schema/entrySchema.ts
@@ -1,7 +1,6 @@
 import { z } from '@hono/zod-openapi';
 import { objectTypeSchema, slugSchema, uuidSchema } from './baseSchema.js';
 import { baseFileSchema } from './fileSchema.js';
-import { gitCommitSchema } from './gitSchema.js';
 import { valueSchema } from './valueSchema.js';
 
 export const entryFileSchema = baseFileSchema.extend({
@@ -10,15 +9,15 @@ export const entryFileSchema = baseFileSchema.extend({
 });
 export type EntryFile = z.infer<typeof entryFileSchema>;
 
-export const entrySchema = entryFileSchema
-  .extend({
-    /**
-     * Commit history of this Entry
-     */
-    history: z.array(gitCommitSchema),
-  })
-  .openapi('Entry');
+export const entrySchema = entryFileSchema.openapi('Entry');
 export type Entry = z.infer<typeof entrySchema>;
+
+export const entryHistorySchema = z.object({
+  id: uuidSchema.readonly(),
+  projectId: uuidSchema.readonly(),
+  collectionId: uuidSchema.readonly(),
+});
+export type EntryHistoryProps = z.infer<typeof entryHistorySchema>;
 
 export const entryExportSchema = entrySchema.extend({});
 export type EntryExport = z.infer<typeof entryExportSchema>;

--- a/src/schema/entrySchema.ts
+++ b/src/schema/entrySchema.ts
@@ -1,12 +1,12 @@
 import { z } from '@hono/zod-openapi';
-import { objectTypeSchema, uuidSchema } from './baseSchema.js';
+import { objectTypeSchema, slugSchema, uuidSchema } from './baseSchema.js';
 import { baseFileSchema } from './fileSchema.js';
 import { gitCommitSchema } from './gitSchema.js';
 import { valueSchema } from './valueSchema.js';
 
 export const entryFileSchema = baseFileSchema.extend({
   objectType: z.literal(objectTypeSchema.enum.entry).readonly(),
-  values: z.array(valueSchema),
+  values: z.record(slugSchema, valueSchema),
 });
 export type EntryFile = z.infer<typeof entryFileSchema>;
 
@@ -33,7 +33,7 @@ export const createEntrySchema = entryFileSchema
   .extend({
     projectId: uuidSchema.readonly(),
     collectionId: uuidSchema.readonly(),
-    values: z.array(valueSchema),
+    values: z.record(slugSchema, valueSchema),
   });
 export type CreateEntryProps = z.infer<typeof createEntrySchema>;
 

--- a/src/schema/entrySchema.ts
+++ b/src/schema/entrySchema.ts
@@ -26,6 +26,7 @@ export const createEntrySchema = entryFileSchema
   .omit({
     id: true,
     objectType: true,
+    coreVersion: true,
     created: true,
     updated: true,
   })
@@ -47,6 +48,7 @@ export type ReadEntryProps = z.infer<typeof readEntrySchema>;
 export const updateEntrySchema = entryFileSchema
   .omit({
     objectType: true,
+    coreVersion: true,
     created: true,
     updated: true,
   })
@@ -58,6 +60,11 @@ export type UpdateEntryProps = z.infer<typeof updateEntrySchema>;
 
 export const deleteEntrySchema = readEntrySchema.extend({});
 export type DeleteEntryProps = z.infer<typeof deleteEntrySchema>;
+
+export const migrateEntrySchema = z.looseObject(
+  entryFileSchema.pick({ id: true, coreVersion: true }).shape
+);
+export type MigrateEntryProps = z.infer<typeof migrateEntrySchema>;
 
 export const countEntriesSchema = z.object({
   projectId: uuidSchema.readonly(),

--- a/src/schema/fieldSchema.ts
+++ b/src/schema/fieldSchema.ts
@@ -1,5 +1,9 @@
 import { z } from '@hono/zod-openapi';
-import { translatableStringSchema, uuidSchema } from './baseSchema.js';
+import {
+  slugSchema,
+  translatableStringSchema,
+  uuidSchema,
+} from './baseSchema.js';
 import { ValueTypeSchema } from './valueSchema.js';
 
 export const FieldTypeSchema = z.enum([
@@ -30,6 +34,7 @@ export const FieldWidthSchema = z.enum(['12', '6', '4', '3']);
 
 export const FieldDefinitionBaseSchema = z.object({
   id: uuidSchema.readonly(),
+  slug: slugSchema,
   label: translatableStringSchema,
   description: translatableStringSchema.nullable(),
   isRequired: z.boolean(),

--- a/src/schema/fieldSchema.ts
+++ b/src/schema/fieldSchema.ts
@@ -4,9 +4,9 @@ import {
   translatableStringSchema,
   uuidSchema,
 } from './baseSchema.js';
-import { ValueTypeSchema } from './valueSchema.js';
+import { valueTypeSchema } from './valueSchema.js';
 
-export const FieldTypeSchema = z.enum([
+export const fieldTypeSchema = z.enum([
   // String Values
   'text',
   'textarea',
@@ -28,11 +28,11 @@ export const FieldTypeSchema = z.enum([
   'entry',
   // 'sharedValue', // @todo
 ]);
-export type FieldType = z.infer<typeof FieldTypeSchema>;
+export type FieldType = z.infer<typeof fieldTypeSchema>;
 
-export const FieldWidthSchema = z.enum(['12', '6', '4', '3']);
+export const fieldWidthSchema = z.enum(['12', '6', '4', '3']);
 
-export const FieldDefinitionBaseSchema = z.object({
+export const fieldDefinitionBaseSchema = z.object({
   id: uuidSchema.readonly(),
   slug: slugSchema,
   label: translatableStringSchema,
@@ -40,24 +40,24 @@ export const FieldDefinitionBaseSchema = z.object({
   isRequired: z.boolean(),
   isDisabled: z.boolean(),
   isUnique: z.boolean(),
-  inputWidth: FieldWidthSchema,
+  inputWidth: fieldWidthSchema,
 });
-export type FieldDefinitionBase = z.infer<typeof FieldDefinitionBaseSchema>;
+export type FieldDefinitionBase = z.infer<typeof fieldDefinitionBaseSchema>;
 
 /**
  * String based Field definitions
  */
 
-export const StringFieldDefinitionBaseSchema = FieldDefinitionBaseSchema.extend(
+export const stringFieldDefinitionBaseSchema = fieldDefinitionBaseSchema.extend(
   {
-    valueType: z.literal(ValueTypeSchema.enum.string),
+    valueType: z.literal(valueTypeSchema.enum.string),
     defaultValue: z.string().nullable(),
   }
 );
 
-export const textFieldDefinitionSchema = StringFieldDefinitionBaseSchema.extend(
+export const textFieldDefinitionSchema = stringFieldDefinitionBaseSchema.extend(
   {
-    fieldType: z.literal(FieldTypeSchema.enum.text),
+    fieldType: z.literal(fieldTypeSchema.enum.text),
     min: z.number().nullable(),
     max: z.number().nullable(),
   }
@@ -65,8 +65,8 @@ export const textFieldDefinitionSchema = StringFieldDefinitionBaseSchema.extend(
 export type TextFieldDefinition = z.infer<typeof textFieldDefinitionSchema>;
 
 export const textareaFieldDefinitionSchema =
-  StringFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.textarea),
+  stringFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.textarea),
     min: z.number().nullable(),
     max: z.number().nullable(),
   });
@@ -75,51 +75,51 @@ export type TextareaFieldDefinition = z.infer<
 >;
 
 export const emailFieldDefinitionSchema =
-  StringFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.email),
+  stringFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.email),
     defaultValue: z.email().nullable(),
   });
 export type EmailFieldDefinition = z.infer<typeof emailFieldDefinitionSchema>;
 
 // @todo why should we support password Values? Client saves it in clear text anyways
 // export const passwordFieldDefinitionSchema =
-//   StringFieldDefinitionBaseSchema.extend({
+//   stringFieldDefinitionBaseSchema.extend({
 //     fieldType: z.literal(FieldfieldTypeSchema.enum.password),
 //   });
 
-export const urlFieldDefinitionSchema = StringFieldDefinitionBaseSchema.extend({
-  fieldType: z.literal(FieldTypeSchema.enum.url),
+export const urlFieldDefinitionSchema = stringFieldDefinitionBaseSchema.extend({
+  fieldType: z.literal(fieldTypeSchema.enum.url),
   defaultValue: z.url().nullable(),
 });
 export type UrlFieldDefinition = z.infer<typeof urlFieldDefinitionSchema>;
 
-export const ipv4FieldDefinitionSchema = StringFieldDefinitionBaseSchema.extend(
+export const ipv4FieldDefinitionSchema = stringFieldDefinitionBaseSchema.extend(
   {
-    fieldType: z.literal(FieldTypeSchema.enum.ipv4),
+    fieldType: z.literal(fieldTypeSchema.enum.ipv4),
     defaultValue: z.ipv4().nullable(),
   }
 );
 export type Ipv4FieldDefinition = z.infer<typeof ipv4FieldDefinitionSchema>;
 
-export const dateFieldDefinitionSchema = StringFieldDefinitionBaseSchema.extend(
+export const dateFieldDefinitionSchema = stringFieldDefinitionBaseSchema.extend(
   {
-    fieldType: z.literal(FieldTypeSchema.enum.date),
+    fieldType: z.literal(fieldTypeSchema.enum.date),
     defaultValue: z.iso.date().nullable(),
   }
 );
 export type DateFieldDefinition = z.infer<typeof dateFieldDefinitionSchema>;
 
-export const timeFieldDefinitionSchema = StringFieldDefinitionBaseSchema.extend(
+export const timeFieldDefinitionSchema = stringFieldDefinitionBaseSchema.extend(
   {
-    fieldType: z.literal(FieldTypeSchema.enum.time),
+    fieldType: z.literal(fieldTypeSchema.enum.time),
     defaultValue: z.iso.time().nullable(),
   }
 );
 export type TimeFieldDefinition = z.infer<typeof timeFieldDefinitionSchema>;
 
 export const datetimeFieldDefinitionSchema =
-  StringFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.datetime),
+  stringFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.datetime),
     defaultValue: z.iso.datetime().nullable(),
   });
 export type DatetimeFieldDefinition = z.infer<
@@ -127,8 +127,8 @@ export type DatetimeFieldDefinition = z.infer<
 >;
 
 export const telephoneFieldDefinitionSchema =
-  StringFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.telephone),
+  stringFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.telephone),
     defaultValue: z.e164().nullable(),
   });
 export type TelephoneFieldDefinition = z.infer<
@@ -152,9 +152,9 @@ export type StringFieldDefinition = z.infer<typeof stringFieldDefinitionSchema>;
  * Number based Field definitions
  */
 
-export const NumberFieldDefinitionBaseSchema = FieldDefinitionBaseSchema.extend(
+export const numberFieldDefinitionBaseSchema = fieldDefinitionBaseSchema.extend(
   {
-    valueType: z.literal(ValueTypeSchema.enum.number),
+    valueType: z.literal(valueTypeSchema.enum.number),
     min: z.number().nullable(),
     max: z.number().nullable(),
     isUnique: z.literal(false),
@@ -163,14 +163,14 @@ export const NumberFieldDefinitionBaseSchema = FieldDefinitionBaseSchema.extend(
 );
 
 export const numberFieldDefinitionSchema =
-  NumberFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.number),
+  numberFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.number),
   });
 export type NumberFieldDefinition = z.infer<typeof numberFieldDefinitionSchema>;
 
 export const rangeFieldDefinitionSchema =
-  NumberFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.range),
+  numberFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.range),
     // Overwrite from nullable to required because a range needs min, max and default to work and is required, since it always returns a number
     isRequired: z.literal(true),
     min: z.number(),
@@ -183,9 +183,9 @@ export type RangeFieldDefinition = z.infer<typeof rangeFieldDefinitionSchema>;
  * Boolean based Field definitions
  */
 
-export const BooleanFieldDefinitionBaseSchema =
-  FieldDefinitionBaseSchema.extend({
-    valueType: z.literal(ValueTypeSchema.enum.boolean),
+export const booleanFieldDefinitionBaseSchema =
+  fieldDefinitionBaseSchema.extend({
+    valueType: z.literal(valueTypeSchema.enum.boolean),
     // Overwrite from nullable to required because a boolean needs a default to work and is required, since it always is either true or false
     isRequired: z.literal(true),
     defaultValue: z.boolean(),
@@ -193,8 +193,8 @@ export const BooleanFieldDefinitionBaseSchema =
   });
 
 export const toggleFieldDefinitionSchema =
-  BooleanFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.toggle),
+  booleanFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.toggle),
   });
 export type ToggleFieldDefinition = z.infer<typeof toggleFieldDefinitionSchema>;
 
@@ -202,22 +202,23 @@ export type ToggleFieldDefinition = z.infer<typeof toggleFieldDefinitionSchema>;
  * Reference based Field definitions
  */
 
-export const ReferenceFieldDefinitionBaseSchema =
-  FieldDefinitionBaseSchema.extend({
-    valueType: z.literal(ValueTypeSchema.enum.reference),
+export const referenceFieldDefinitionBaseSchema =
+  fieldDefinitionBaseSchema.extend({
+    valueType: z.literal(valueTypeSchema.enum.reference),
+    isUnique: z.literal(false),
   });
 
 export const assetFieldDefinitionSchema =
-  ReferenceFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.asset),
+  referenceFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.asset),
     min: z.number().nullable(),
     max: z.number().nullable(),
   });
 export type AssetFieldDefinition = z.infer<typeof assetFieldDefinitionSchema>;
 
 export const entryFieldDefinitionSchema =
-  ReferenceFieldDefinitionBaseSchema.extend({
-    fieldType: z.literal(FieldTypeSchema.enum.entry),
+  referenceFieldDefinitionBaseSchema.extend({
+    fieldType: z.literal(fieldTypeSchema.enum.entry),
     ofCollections: z.array(uuidSchema),
     min: z.number().nullable(),
     max: z.number().nullable(),
@@ -230,9 +231,9 @@ export type EntryFieldDefinition = z.infer<typeof entryFieldDefinitionSchema>;
 //     // The shared Value can have any of the direct types
 //     // but not any reference itself (a shared Value cannot have a reference to another shared Value / Asset or any other future reference)
 //     sharedValueType: z.union([
-//       z.literal(ValueTypeSchema.enum.boolean),
-//       z.literal(ValueTypeSchema.enum.number),
-//       z.literal(ValueTypeSchema.enum.string),
+//       z.literal(valueTypeSchema.enum.boolean),
+//       z.literal(valueTypeSchema.enum.number),
+//       z.literal(valueTypeSchema.enum.string),
 //     ]),
 //   });
 // export type SharedValueValueDefinition = z.infer<

--- a/src/schema/fileSchema.ts
+++ b/src/schema/fileSchema.ts
@@ -31,3 +31,11 @@ export const fileReferenceSchema = z.object({
   extension: z.string().optional(),
 });
 export type FileReference = z.infer<typeof fileReferenceSchema>;
+
+/**
+ * Schema for the collection index file (collections/index.json).
+ * Maps collection UUIDs to their slug.plural values.
+ * This is a local performance cache, not git-tracked.
+ */
+export const collectionIndexSchema = z.record(uuidSchema, z.string());
+export type CollectionIndex = z.infer<typeof collectionIndexSchema>;

--- a/src/schema/fileSchema.ts
+++ b/src/schema/fileSchema.ts
@@ -1,5 +1,5 @@
 import { z } from '@hono/zod-openapi';
-import { objectTypeSchema, uuidSchema } from './baseSchema.js';
+import { objectTypeSchema, uuidSchema, versionSchema } from './baseSchema.js';
 
 /**
  * A basic file structure every elek.io file on disk has to follow
@@ -16,13 +16,17 @@ export const baseFileSchema = z.object({
    */
   id: uuidSchema.readonly(),
   /**
+   * The version of elek.io Core used to create or last update this file
+   */
+  coreVersion: versionSchema.readonly(),
+  /**
    * The datetime of the file being created is set by the service of "objectType" while creating it
    */
   created: z.string().datetime().readonly(),
   /**
    * The datetime of the file being updated is set by the service of "objectType" while updating it
    */
-  updated: z.string().datetime().nullable(),
+  updated: z.string().datetime().nullable().readonly(),
 });
 export type BaseFile = z.infer<typeof baseFileSchema>;
 

--- a/src/schema/gitSchema.ts
+++ b/src/schema/gitSchema.ts
@@ -1,11 +1,11 @@
 import { z } from '@hono/zod-openapi';
-import { objectTypeSchema, uuidSchema } from './baseSchema.js';
+import { objectTypeSchema, uuidSchema, versionSchema } from './baseSchema.js';
 
 /**
  * Signature git uses to identify users
  */
 export const gitSignatureSchema = z.object({
-  name: z.string(),
+  name: z.string().regex(/^[^|]+$/, 'Name must not contain pipe characters'),
   email: z.string().email(),
 });
 export type GitSignature = z.infer<typeof gitSignatureSchema>;
@@ -26,11 +26,27 @@ export const gitMessageSchema = z.object({
 });
 export type GitMessage = z.infer<typeof gitMessageSchema>;
 
+export const gitTagMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('release'),
+    version: versionSchema,
+  }),
+  z.object({
+    type: z.literal('preview'),
+    version: versionSchema,
+  }),
+  z.object({
+    type: z.literal('upgrade'),
+    coreVersion: versionSchema,
+  }),
+]);
+export type GitTagMessage = z.infer<typeof gitTagMessageSchema>;
+
 export const gitTagSchema = z.object({
   id: uuidSchema,
-  message: z.string(),
+  message: gitTagMessageSchema,
   author: gitSignatureSchema,
-  datetime: z.string().datetime(),
+  datetime: z.iso.datetime(),
 });
 export type GitTag = z.infer<typeof gitTagSchema>;
 
@@ -38,10 +54,10 @@ export const gitCommitSchema = z.object({
   /**
    * SHA-1 hash of the commit
    */
-  hash: z.string(),
+  hash: z.hash('sha1'),
   message: gitMessageSchema,
   author: gitSignatureSchema,
-  datetime: z.string().datetime(),
+  datetime: z.iso.datetime(),
   tag: gitTagSchema.nullable(),
 });
 export type GitCommit = z.infer<typeof gitCommitSchema>;

--- a/src/schema/gitSchema.ts
+++ b/src/schema/gitSchema.ts
@@ -11,7 +11,7 @@ export const gitSignatureSchema = z.object({
 export type GitSignature = z.infer<typeof gitSignatureSchema>;
 
 export const gitMessageSchema = z.object({
-  method: z.enum(['create', 'update', 'delete', 'upgrade']),
+  method: z.enum(['create', 'update', 'delete', 'upgrade', 'release']),
   reference: z.object({
     objectType: objectTypeSchema,
     /**

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -13,3 +13,4 @@ export * from './userSchema.js';
 export * from './valueSchema.js';
 export * from './cliSchema.js';
 export * from './logSchema.js';
+export * from './releaseSchema.js';

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -14,3 +14,4 @@ export * from './valueSchema.js';
 export * from './cliSchema.js';
 export * from './logSchema.js';
 export * from './releaseSchema.js';
+export * from './migrationSchema.js';

--- a/src/schema/migrationSchema.ts
+++ b/src/schema/migrationSchema.ts
@@ -1,0 +1,13 @@
+import type { Version } from './baseSchema.js';
+
+export interface Migration {
+  /** The coreVersion this migration transforms FROM (exact match) */
+  from: Version;
+  /** The coreVersion after this migration has been applied */
+  to: Version;
+  /**
+   * Pure function: receives loose-parsed data, returns a new transformed object.
+   * Must NOT mutate the input. Must NOT set `coreVersion` — that is handled by `applyMigrations`.
+   */
+  run: (data: Record<string, unknown>) => Record<string, unknown>;
+}

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -74,12 +74,9 @@ export const projectHistoryResultSchema = z.object({
 });
 export type ProjectHistoryResult = z.infer<typeof projectHistoryResultSchema>;
 
-export const migrateProjectSchema = projectFileSchema
-  .pick({
-    id: true,
-    coreVersion: true,
-  })
-  .loose();
+export const migrateProjectSchema = z.looseObject(
+  projectFileSchema.pick({ id: true, coreVersion: true }).shape
+);
 export type MigrateProjectProps = z.infer<typeof migrateProjectSchema>;
 
 export const projectExportSchema = projectSchema.extend({

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -51,16 +51,25 @@ export const projectSchema = projectFileSchema
     remoteOriginUrl: z.string().nullable().openapi({
       description: 'URL of the remote Git repository',
     }),
-    history: z.array(gitCommitSchema).openapi({
-      description: 'Commit history of this Project',
-    }),
-    fullHistory: z.array(gitCommitSchema).openapi({
-      description:
-        'Full commit history of this Project including all Assets, Collections, Entries and other files',
-    }),
   })
   .openapi('Project');
 export type Project = z.infer<typeof projectSchema>;
+
+export const projectHistorySchema = z.object({
+  id: uuidSchema.readonly(),
+});
+export type ProjectHistoryProps = z.infer<typeof projectHistorySchema>;
+
+export const projectHistoryResultSchema = z.object({
+  history: z.array(gitCommitSchema).openapi({
+    description: 'Commit history of this Project',
+  }),
+  fullHistory: z.array(gitCommitSchema).openapi({
+    description:
+      'Full commit history of this Project including all Assets, Collections, Entries and other files',
+  }),
+});
+export type ProjectHistoryResult = z.infer<typeof projectHistoryResultSchema>;
 
 export const migrateProjectSchema = projectFileSchema
   .pick({

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -13,10 +13,11 @@ import { gitCommitSchema, gitSwitchOptionsSchema } from './gitSchema.js';
 export const projectSettingsSchema = z.object({
   language: z.object({
     default: supportedLanguageSchema,
-    supported: z.array(supportedLanguageSchema).refine(
-      (langs) => new Set(langs).size === langs.length,
-      { message: 'Supported languages must not contain duplicates' }
-    ),
+    supported: z
+      .array(supportedLanguageSchema)
+      .refine((langs) => new Set(langs).size === langs.length, {
+        message: 'Supported languages must not contain duplicates',
+      }),
   }),
 });
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -16,7 +16,10 @@ export type ProjectStatus = z.infer<typeof projectStatusSchema>;
 export const projectSettingsSchema = z.object({
   language: z.object({
     default: supportedLanguageSchema,
-    supported: z.array(supportedLanguageSchema),
+    supported: z.array(supportedLanguageSchema).refine(
+      (langs) => new Set(langs).size === langs.length,
+      { message: 'Supported languages must not contain duplicates' }
+    ),
   }),
 });
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -115,21 +115,6 @@ export const deleteProjectSchema = readProjectSchema.extend({
 });
 export type DeleteProjectProps = z.infer<typeof deleteProjectSchema>;
 
-export const projectUpgradeSchema = z.object({
-  /**
-   * The Core version the Project will be upgraded to
-   */
-  to: versionSchema.readonly(),
-  /**
-   * Function that will be executed in the process of upgrading a Project
-   */
-  run: z.function({
-    input: [projectFileSchema],
-    output: z.promise(z.void()),
-  }),
-});
-export type ProjectUpgrade = z.infer<typeof projectUpgradeSchema>;
-
 export const cloneProjectSchema = z.object({
   url: z.string(),
 });

--- a/src/schema/projectSchema.ts
+++ b/src/schema/projectSchema.ts
@@ -10,9 +10,6 @@ import { collectionExportSchema } from './collectionSchema.js';
 import { baseFileSchema } from './fileSchema.js';
 import { gitCommitSchema, gitSwitchOptionsSchema } from './gitSchema.js';
 
-export const projectStatusSchema = z.enum(['foo', 'bar', 'todo']);
-export type ProjectStatus = z.infer<typeof projectStatusSchema>;
-
 export const projectSettingsSchema = z.object({
   language: z.object({
     default: supportedLanguageSchema,
@@ -40,11 +37,9 @@ export type ProjectBranch = z.infer<typeof projectBranchSchema>;
 
 export const projectFileSchema = baseFileSchema.extend({
   objectType: z.literal(objectTypeSchema.enum.project).readonly(),
-  coreVersion: versionSchema,
   name: z.string().trim().min(1),
   description: z.string().trim().min(1),
   version: versionSchema,
-  status: projectStatusSchema,
   settings: projectSettingsSchema,
 });
 export type ProjectFile = z.infer<typeof projectFileSchema>;

--- a/src/schema/releaseSchema.ts
+++ b/src/schema/releaseSchema.ts
@@ -110,15 +110,6 @@ export const createReleaseSchema = z.object({
 });
 export type CreateReleaseProps = z.infer<typeof createReleaseSchema>;
 
-export const releaseTypeSchema = z.enum(['release', 'preview']);
-export type ReleaseType = z.infer<typeof releaseTypeSchema>;
-
-export const releaseTagMessageSchema = z.object({
-  type: releaseTypeSchema,
-  version: versionSchema,
-});
-export type ReleaseTagMessage = z.infer<typeof releaseTagMessageSchema>;
-
 export const createPreviewReleaseSchema = z.object({
   projectId: uuidSchema.readonly(),
 });

--- a/src/schema/releaseSchema.ts
+++ b/src/schema/releaseSchema.ts
@@ -48,7 +48,6 @@ export type CollectionChange = z.infer<typeof collectionChangeSchema>;
 export const projectChangeTypeSchema = z.enum([
   'nameChanged',
   'descriptionChanged',
-  'statusChanged',
   'defaultLanguageChanged',
   'supportedLanguageAdded',
   'supportedLanguageRemoved',

--- a/src/schema/releaseSchema.ts
+++ b/src/schema/releaseSchema.ts
@@ -1,0 +1,88 @@
+import { z } from '@hono/zod-openapi';
+import { uuidSchema, versionSchema } from './baseSchema.js';
+import { projectSchema } from './projectSchema.js';
+
+export const semverBumpSchema = z.enum(['major', 'minor', 'patch']);
+export type SemverBump = z.infer<typeof semverBumpSchema>;
+
+export const fieldChangeTypeSchema = z.enum([
+  'added',
+  'deleted',
+  'valueTypeChanged',
+  'fieldTypeChanged',
+  'slugChanged',
+  'minMaxTightened',
+  'isRequiredToNotRequired',
+  'isUniqueToNotUnique',
+  'ofCollectionsChanged',
+  'isNotRequiredToRequired',
+  'isNotUniqueToUnique',
+  'labelChanged',
+  'descriptionChanged',
+  'defaultValueChanged',
+  'inputWidthChanged',
+  'isDisabledChanged',
+  'minMaxLoosened',
+]);
+export type FieldChangeType = z.infer<typeof fieldChangeTypeSchema>;
+
+export const fieldChangeSchema = z.object({
+  collectionId: uuidSchema,
+  fieldId: uuidSchema,
+  fieldSlug: z.string(),
+  changeType: fieldChangeTypeSchema,
+  bump: semverBumpSchema,
+});
+export type FieldChange = z.infer<typeof fieldChangeSchema>;
+
+export const collectionChangeTypeSchema = z.enum(['added', 'deleted']);
+export type CollectionChangeType = z.infer<typeof collectionChangeTypeSchema>;
+
+export const collectionChangeSchema = z.object({
+  collectionId: uuidSchema,
+  changeType: collectionChangeTypeSchema,
+  bump: semverBumpSchema,
+});
+export type CollectionChange = z.infer<typeof collectionChangeSchema>;
+
+export const releaseDiffSchema = z.object({
+  project: projectSchema,
+  bump: semverBumpSchema.nullable(),
+  currentVersion: versionSchema,
+  nextVersion: versionSchema.nullable(),
+  collectionChanges: z.array(collectionChangeSchema),
+  fieldChanges: z.array(fieldChangeSchema),
+});
+export type ReleaseDiff = z.infer<typeof releaseDiffSchema>;
+
+export const prepareReleaseSchema = z.object({
+  projectId: uuidSchema.readonly(),
+});
+export type PrepareReleaseProps = z.infer<typeof prepareReleaseSchema>;
+
+export const createReleaseSchema = z.object({
+  projectId: uuidSchema.readonly(),
+});
+export type CreateReleaseProps = z.infer<typeof createReleaseSchema>;
+
+export const releaseTypeSchema = z.enum(['release', 'preview']);
+export type ReleaseType = z.infer<typeof releaseTypeSchema>;
+
+export const releaseTagMessageSchema = z.object({
+  type: releaseTypeSchema,
+  version: versionSchema,
+});
+export type ReleaseTagMessage = z.infer<typeof releaseTagMessageSchema>;
+
+export const createPreviewReleaseSchema = z.object({
+  projectId: uuidSchema.readonly(),
+});
+export type CreatePreviewReleaseProps = z.infer<
+  typeof createPreviewReleaseSchema
+>;
+
+export const releaseResultSchema = z.object({
+  version: versionSchema,
+  diff: releaseDiffSchema,
+});
+export type ReleaseResult = z.infer<typeof releaseResultSchema>;

--- a/src/schema/releaseSchema.ts
+++ b/src/schema/releaseSchema.ts
@@ -45,13 +45,58 @@ export const collectionChangeSchema = z.object({
 });
 export type CollectionChange = z.infer<typeof collectionChangeSchema>;
 
+export const projectChangeTypeSchema = z.enum([
+  'nameChanged',
+  'descriptionChanged',
+  'statusChanged',
+  'defaultLanguageChanged',
+  'supportedLanguageAdded',
+  'supportedLanguageRemoved',
+]);
+export type ProjectChangeType = z.infer<typeof projectChangeTypeSchema>;
+
+export const projectChangeSchema = z.object({
+  changeType: projectChangeTypeSchema,
+  bump: semverBumpSchema,
+});
+export type ProjectChange = z.infer<typeof projectChangeSchema>;
+
+export const assetChangeTypeSchema = z.enum([
+  'added',
+  'deleted',
+  'metadataChanged',
+  'binaryChanged',
+]);
+export type AssetChangeType = z.infer<typeof assetChangeTypeSchema>;
+
+export const assetChangeSchema = z.object({
+  assetId: uuidSchema,
+  changeType: assetChangeTypeSchema,
+  bump: semverBumpSchema,
+});
+export type AssetChange = z.infer<typeof assetChangeSchema>;
+
+export const entryChangeTypeSchema = z.enum(['added', 'deleted', 'modified']);
+export type EntryChangeType = z.infer<typeof entryChangeTypeSchema>;
+
+export const entryChangeSchema = z.object({
+  collectionId: uuidSchema,
+  entryId: uuidSchema,
+  changeType: entryChangeTypeSchema,
+  bump: semverBumpSchema,
+});
+export type EntryChange = z.infer<typeof entryChangeSchema>;
+
 export const releaseDiffSchema = z.object({
   project: projectSchema,
   bump: semverBumpSchema.nullable(),
   currentVersion: versionSchema,
   nextVersion: versionSchema.nullable(),
+  projectChanges: z.array(projectChangeSchema),
   collectionChanges: z.array(collectionChangeSchema),
   fieldChanges: z.array(fieldChangeSchema),
+  assetChanges: z.array(assetChangeSchema),
+  entryChanges: z.array(entryChangeSchema),
 });
 export type ReleaseDiff = z.infer<typeof releaseDiffSchema>;
 

--- a/src/schema/schemaFromFieldDefinition.test.ts
+++ b/src/schema/schemaFromFieldDefinition.test.ts
@@ -13,25 +13,21 @@ import { getValueSchemaFromFieldDefinition } from './schemaFromFieldDefinition.j
 describe('Dynamic zod schema from field definition', () => {
   const defaultBooleanValue: DirectBooleanValue = {
     objectType: 'value',
-    fieldDefinitionId: uuid(),
     valueType: 'boolean',
     content: {},
   };
   const defaultNumberValue: DirectNumberValue = {
     objectType: 'value',
-    fieldDefinitionId: uuid(),
     valueType: 'number',
     content: {},
   };
   const defaultStringValue: DirectStringValue = {
     objectType: 'value',
-    fieldDefinitionId: uuid(),
     valueType: 'string',
     content: {},
   };
   const defaultReferenceValue: ReferencedValue = {
     objectType: 'value',
-    fieldDefinitionId: uuid(),
     valueType: 'reference',
     content: {},
   };
@@ -39,6 +35,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from toggle Field definition can be generated and parsed with', () => {
     const booleanValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'boolean',
       fieldType: 'toggle',
       label: {
@@ -104,6 +101,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required number Field type definition can be generated and parsed with', () => {
     const requiredNumberValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'number',
       fieldType: 'number',
       label: {
@@ -187,6 +185,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from optional number Field type definition can be generated and parsed with', () => {
     const optionalNumberValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'number',
       fieldType: 'number',
       label: {
@@ -268,6 +267,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required range Field type definition can be generated and parsed with', () => {
     const requiredRangeValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'number',
       fieldType: 'range',
       label: {
@@ -351,6 +351,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required text Field type definition can be generated and parsed with', () => {
     const requiredTextValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'text',
       label: {
@@ -444,6 +445,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from optional text Field type definition can be generated and parsed with', () => {
     const optionalTextValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'text',
       label: {
@@ -523,6 +525,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required email Field type definition can be generated and parsed with', () => {
     const requiredEmailValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'email',
       label: {
@@ -614,6 +617,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from optional email Field type definition can be generated and parsed with', () => {
     const optionalEmailValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'email',
       label: {
@@ -703,6 +707,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required url Field type definition can be generated and parsed with', () => {
     const requiredUrlValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'url',
       label: {
@@ -810,6 +815,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from optional url Field type definition can be generated and parsed with', () => {
     const optionalUrlValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'url',
       label: { en: 'Test' },
@@ -867,6 +873,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required ipv4 Field type definition can be generated and parsed with', () => {
     const requiredIpValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'ipv4',
       label: { en: 'Test' },
@@ -925,6 +932,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required date Field type definition can be generated and parsed with', () => {
     const requiredDateValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'date',
       label: { en: 'Test' },
@@ -981,6 +989,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required time Field type definition can be generated and parsed with', () => {
     const requiredTimeValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'time',
       label: { en: 'Test' },
@@ -1044,6 +1053,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required datetime Field type definition can be generated and parsed with', () => {
     const requiredDatetimeValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'datetime',
       label: { en: 'Test' },
@@ -1100,6 +1110,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required telephone Field type definition can be generated and parsed with', () => {
     const requiredTelephoneValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'string',
       fieldType: 'telephone',
       label: { en: 'Test' },
@@ -1155,6 +1166,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required Asset Field type definition can be generated and parsed with', () => {
     const requiredAssetValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'reference',
       fieldType: 'asset',
       label: { en: 'Test' },
@@ -1225,6 +1237,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from optional Asset Field type definition can be generated and parsed with', () => {
     const optionalAssetValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'reference',
       fieldType: 'asset',
       label: { en: 'Test' },
@@ -1279,6 +1292,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required Asset Field type definition with a min and max can be generated and parsed with', () => {
     const requiredAssetValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'reference',
       fieldType: 'asset',
       label: { en: 'Test' },
@@ -1369,6 +1383,7 @@ describe('Dynamic zod schema from field definition', () => {
   it('from required Entry Field type definition can be generated and parsed with', () => {
     const requiredEntryValueschema = getValueSchemaFromFieldDefinition({
       id: uuid(),
+      slug: 'test-field',
       valueType: 'reference',
       fieldType: 'entry',
       label: { en: 'Test' },
@@ -1433,19 +1448,17 @@ describe('Dynamic zod schema from field definition', () => {
     const entry: Entry = {
       objectType: 'entry',
       id: 'f405301c-3c31-4edd-ab6b-1735d2757044',
-      values: [
-        {
+      values: {
+        title: {
           objectType: 'value',
           valueType: 'string',
-          fieldDefinitionId: 'e9da15ab-28e2-40fe-be78-de09bf1790b3',
           content: {
             en: 'Bacon',
           },
         },
-        {
+        image: {
           objectType: 'value',
           valueType: 'reference',
-          fieldDefinitionId: '9a317f2c-db60-4929-8110-79905490aef3',
           content: {
             en: [
               {
@@ -1455,10 +1468,9 @@ describe('Dynamic zod schema from field definition', () => {
             ],
           },
         },
-        {
+        'related-entries': {
           objectType: 'value',
           valueType: 'reference',
-          fieldDefinitionId: 'a7e3d49c-8565-4e79-9428-233968b73b27',
           content: {
             en: [
               {
@@ -1468,7 +1480,7 @@ describe('Dynamic zod schema from field definition', () => {
             ],
           },
         },
-      ],
+      },
       history: [],
       created: '2024-07-16T12:42:27.897Z',
       updated: null,

--- a/src/schema/schemaFromFieldDefinition.test.ts
+++ b/src/schema/schemaFromFieldDefinition.test.ts
@@ -1481,7 +1481,6 @@ describe('Dynamic zod schema from field definition', () => {
           },
         },
       },
-      history: [],
       created: '2024-07-16T12:42:27.897Z',
       updated: null,
     };

--- a/src/schema/schemaFromFieldDefinition.test.ts
+++ b/src/schema/schemaFromFieldDefinition.test.ts
@@ -1448,6 +1448,7 @@ describe('Dynamic zod schema from field definition', () => {
     const entry: Entry = {
       objectType: 'entry',
       id: 'f405301c-3c31-4edd-ab6b-1735d2757044',
+      coreVersion: '0.16.2',
       values: {
         title: {
           objectType: 'value',

--- a/src/schema/schemaFromFieldDefinition.ts
+++ b/src/schema/schemaFromFieldDefinition.ts
@@ -236,23 +236,30 @@ export function getValueSchemaFromFieldDefinition(
 }
 
 /**
+ * Builds a z.object shape from field definitions, keyed by slug
+ */
+function getValuesShapeFromFieldDefinitions(
+  fieldDefinitions: FieldDefinition[]
+) {
+  const shape: Record<
+    string,
+    ReturnType<typeof getValueSchemaFromFieldDefinition>
+  > = {};
+  for (const fieldDef of fieldDefinitions) {
+    shape[fieldDef.slug] = getValueSchemaFromFieldDefinition(fieldDef);
+  }
+  return shape;
+}
+
+/**
  * Generates a schema for an Entry based on the given Field definitions and Values
  */
 export function getEntrySchemaFromFieldDefinitions(
   fieldDefinitions: FieldDefinition[]
 ) {
-  const valueSchemas = fieldDefinitions.map((fieldDefinition) => {
-    return getValueSchemaFromFieldDefinition(fieldDefinition);
-  });
-
   return z.object({
     ...entrySchema.shape,
-    values: z.tuple(
-      valueSchemas as [
-        (typeof valueSchemas)[number],
-        ...(typeof valueSchemas)[number][],
-      ] // At least one element is required in a tuple
-    ),
+    values: z.object(getValuesShapeFromFieldDefinitions(fieldDefinitions)),
   });
 }
 
@@ -262,18 +269,9 @@ export function getEntrySchemaFromFieldDefinitions(
 export function getCreateEntrySchemaFromFieldDefinitions(
   fieldDefinitions: FieldDefinition[]
 ) {
-  const valueSchemas = fieldDefinitions.map((fieldDefinition) => {
-    return getValueSchemaFromFieldDefinition(fieldDefinition);
-  });
-
   return z.object({
     ...createEntrySchema.shape,
-    values: z.tuple(
-      valueSchemas as [
-        (typeof valueSchemas)[number],
-        ...(typeof valueSchemas)[number][],
-      ] // At least one element is required in a tuple
-    ),
+    values: z.object(getValuesShapeFromFieldDefinitions(fieldDefinitions)),
   });
 }
 
@@ -283,17 +281,8 @@ export function getCreateEntrySchemaFromFieldDefinitions(
 export function getUpdateEntrySchemaFromFieldDefinitions(
   fieldDefinitions: FieldDefinition[]
 ) {
-  const valueSchemas = fieldDefinitions.map((fieldDefinition) => {
-    return getValueSchemaFromFieldDefinition(fieldDefinition);
-  });
-
   return z.object({
     ...updateEntrySchema.shape,
-    values: z.tuple(
-      valueSchemas as [
-        (typeof valueSchemas)[number],
-        ...(typeof valueSchemas)[number][],
-      ] // At least one element is required in a tuple
-    ),
+    values: z.object(getValuesShapeFromFieldDefinitions(fieldDefinitions)),
   });
 }

--- a/src/schema/schemaFromFieldDefinition.ts
+++ b/src/schema/schemaFromFieldDefinition.ts
@@ -20,7 +20,7 @@ import type {
   RangeFieldDefinition,
   StringFieldDefinition,
 } from './fieldSchema.js';
-import { FieldTypeSchema } from './fieldSchema.js';
+import { fieldTypeSchema } from './fieldSchema.js';
 import {
   directBooleanValueSchema,
   directNumberValueSchema,
@@ -28,7 +28,7 @@ import {
   referencedValueSchema,
   valueContentReferenceToAssetSchema,
   valueContentReferenceToEntrySchema,
-  ValueTypeSchema,
+  valueTypeSchema,
 } from './valueSchema.js';
 
 /**
@@ -70,29 +70,29 @@ function getStringValueContentSchemaFromFieldDefinition(
   let schema = null;
 
   switch (fieldDefinition.fieldType) {
-    case FieldTypeSchema.enum.email:
+    case fieldTypeSchema.enum.email:
       schema = z.email();
       break;
-    case FieldTypeSchema.enum.url:
+    case fieldTypeSchema.enum.url:
       schema = z.url();
       break;
-    case FieldTypeSchema.enum.ipv4:
+    case fieldTypeSchema.enum.ipv4:
       schema = z.ipv4();
       break;
-    case FieldTypeSchema.enum.date:
+    case fieldTypeSchema.enum.date:
       schema = z.iso.date();
       break;
-    case FieldTypeSchema.enum.time:
+    case fieldTypeSchema.enum.time:
       schema = z.iso.time();
       break;
-    case FieldTypeSchema.enum.datetime:
+    case fieldTypeSchema.enum.datetime:
       schema = z.iso.datetime();
       break;
-    case FieldTypeSchema.enum.telephone:
+    case fieldTypeSchema.enum.telephone:
       schema = z.e164();
       break;
-    case FieldTypeSchema.enum.text:
-    case FieldTypeSchema.enum.textarea:
+    case fieldTypeSchema.enum.text:
+    case fieldTypeSchema.enum.textarea:
       schema = z.string().trim();
       break;
   }
@@ -121,12 +121,12 @@ function getReferenceValueContentSchemaFromFieldDefinition(
   let schema;
 
   switch (fieldDefinition.fieldType) {
-    case FieldTypeSchema.enum.asset:
+    case fieldTypeSchema.enum.asset:
       {
         schema = z.array(valueContentReferenceToAssetSchema);
       }
       break;
-    case FieldTypeSchema.enum.entry:
+    case fieldTypeSchema.enum.entry:
       {
         schema = z.array(valueContentReferenceToEntrySchema);
       }
@@ -202,25 +202,25 @@ export function getValueSchemaFromFieldDefinition(
   fieldDefinition: FieldDefinition
 ) {
   switch (fieldDefinition.valueType) {
-    case ValueTypeSchema.enum.boolean:
+    case valueTypeSchema.enum.boolean:
       return directBooleanValueSchema.extend({
         content: getTranslatableBooleanValueContentSchemaFromFieldDefinition(),
       });
-    case ValueTypeSchema.enum.number:
+    case valueTypeSchema.enum.number:
       return directNumberValueSchema.extend({
         content:
           getTranslatableNumberValueContentSchemaFromFieldDefinition(
             fieldDefinition
           ),
       });
-    case ValueTypeSchema.enum.string:
+    case valueTypeSchema.enum.string:
       return directStringValueSchema.extend({
         content:
           getTranslatableStringValueContentSchemaFromFieldDefinition(
             fieldDefinition
           ),
       });
-    case ValueTypeSchema.enum.reference:
+    case valueTypeSchema.enum.reference:
       return referencedValueSchema.extend({
         content:
           getTranslatableReferenceValueContentSchemaFromFieldDefinition(

--- a/src/schema/serviceSchema.ts
+++ b/src/schema/serviceSchema.ts
@@ -12,6 +12,7 @@ export const serviceTypeSchema = z.enum([
   'Collection',
   'Entry',
   'Value',
+  'Release',
 ]);
 export type ServiceType = z.infer<typeof serviceTypeSchema>;
 

--- a/src/schema/userSchema.ts
+++ b/src/schema/userSchema.ts
@@ -2,10 +2,10 @@ import { z } from '@hono/zod-openapi';
 import { supportedLanguageSchema, uuidSchema } from './baseSchema.js';
 import { gitSignatureSchema } from './gitSchema.js';
 
-export const UserTypeSchema = z.enum(['local', 'cloud']);
+export const userTypeSchema = z.enum(['local', 'cloud']);
 
 export const baseUserSchema = gitSignatureSchema.extend({
-  userType: UserTypeSchema,
+  userType: userTypeSchema,
   language: supportedLanguageSchema,
   localApi: z.object({
     /**
@@ -21,12 +21,12 @@ export const baseUserSchema = gitSignatureSchema.extend({
 export type BaseUser = z.infer<typeof baseUserSchema>;
 
 export const localUserSchema = baseUserSchema.extend({
-  userType: z.literal(UserTypeSchema.enum.local),
+  userType: z.literal(userTypeSchema.enum.local),
 });
 export type LocalUser = z.infer<typeof localUserSchema>;
 
 export const cloudUserSchema = baseUserSchema.extend({
-  userType: z.literal(UserTypeSchema.enum.cloud),
+  userType: z.literal(userTypeSchema.enum.cloud),
   id: uuidSchema,
 });
 export type CloudUser = z.infer<typeof cloudUserSchema>;

--- a/src/schema/valueSchema.ts
+++ b/src/schema/valueSchema.ts
@@ -100,7 +100,6 @@ export type ValueContentReference = z.infer<typeof valueContentReferenceSchema>;
 
 export const directValueBaseSchema = z.object({
   objectType: z.literal(objectTypeSchema.enum.value).readonly(),
-  fieldDefinitionId: uuidSchema.readonly(),
 });
 
 export const directStringValueSchema = directValueBaseSchema.extend({
@@ -130,7 +129,6 @@ export type DirectValue = z.infer<typeof directValueSchema>;
 
 export const referencedValueSchema = z.object({
   objectType: z.literal(objectTypeSchema.enum.value).readonly(),
-  fieldDefinitionId: uuidSchema.readonly(),
   valueType: z.literal(ValueTypeSchema.enum.reference).readonly(),
   content: translatableArrayOf(valueContentReferenceSchema),
 });

--- a/src/schema/valueSchema.ts
+++ b/src/schema/valueSchema.ts
@@ -8,13 +8,13 @@ import {
   uuidSchema,
 } from './baseSchema.js';
 
-export const ValueTypeSchema = z.enum([
+export const valueTypeSchema = z.enum([
   'string',
   'number',
   'boolean',
   'reference',
 ]);
-export type ValueType = z.infer<typeof ValueTypeSchema>;
+export type ValueType = z.infer<typeof valueTypeSchema>;
 
 export const valueContentReferenceBase = z.object({
   id: uuidSchema,
@@ -57,8 +57,8 @@ export type ValueContentReferenceToEntry = z.infer<
 
 // export const sharedValueFileSchema = baseFileWithLanguageSchema.extend({
 //   objectType: z.literal(objectTypeSchema.enum.sharedValue).readonly(),
-//   valueType: ValueTypeSchema.exclude(['reference']).readonly(),
-//   // valueType: ValueTypeSchema.readonly(), @todo do we allow shared Values to reference assets or others?
+//   valueType: valueTypeSchema.exclude(['reference']).readonly(),
+//   // valueType: valueTypeSchema.readonly(), @todo do we allow shared Values to reference assets or others?
 //   content: z.union([
 //     z.string(),
 //     z.number(),
@@ -103,19 +103,19 @@ export const directValueBaseSchema = z.object({
 });
 
 export const directStringValueSchema = directValueBaseSchema.extend({
-  valueType: z.literal(ValueTypeSchema.enum.string).readonly(),
+  valueType: z.literal(valueTypeSchema.enum.string).readonly(),
   content: translatableStringSchema,
 });
 export type DirectStringValue = z.infer<typeof directStringValueSchema>;
 
 export const directNumberValueSchema = directValueBaseSchema.extend({
-  valueType: z.literal(ValueTypeSchema.enum.number).readonly(),
+  valueType: z.literal(valueTypeSchema.enum.number).readonly(),
   content: translatableNumberSchema,
 });
 export type DirectNumberValue = z.infer<typeof directNumberValueSchema>;
 
 export const directBooleanValueSchema = directValueBaseSchema.extend({
-  valueType: z.literal(ValueTypeSchema.enum.boolean).readonly(),
+  valueType: z.literal(valueTypeSchema.enum.boolean).readonly(),
   content: translatableBooleanSchema,
 });
 export type DirectBooleanValue = z.infer<typeof directBooleanValueSchema>;
@@ -129,7 +129,7 @@ export type DirectValue = z.infer<typeof directValueSchema>;
 
 export const referencedValueSchema = z.object({
   objectType: z.literal(objectTypeSchema.enum.value).readonly(),
-  valueType: z.literal(ValueTypeSchema.enum.reference).readonly(),
+  valueType: z.literal(valueTypeSchema.enum.reference).readonly(),
   content: translatableArrayOf(valueContentReferenceSchema),
 });
 export type ReferencedValue = z.infer<typeof referencedValueSchema>;

--- a/src/service/AssetService.test.ts
+++ b/src/service/AssetService.test.ts
@@ -35,7 +35,8 @@ describe('AssetService', function () {
     ).to.approximately(Math.floor(Date.now() / 1000), 5); // 5 seconds of delta allowed
     expect(asset.extension).toEqual('png');
     expect(asset.mimeType).toEqual('image/png');
-    expect(asset.history.length).toEqual(1);
+    const createHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    expect(createHistory.length).toEqual(1);
     expect(
       await Fs.pathExists(core.util.pathTo.assetFile(project.id, asset.id)),
       'the AssetFile to be created for saving additional meta data of the Asset'
@@ -69,7 +70,8 @@ describe('AssetService', function () {
     });
 
     expect(asset.description).toEqual('A 150x150 image of the text "elek.io"');
-    expect(asset.history.length).toEqual(2);
+    const updateHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    expect(updateHistory.length).toEqual(2);
   });
 
   it('should be able to update an Asset with a new file', async function () {
@@ -82,11 +84,13 @@ describe('AssetService', function () {
 
     expect(asset.extension).toEqual('jpg');
     expect(asset.size).toEqual(1342);
-    expect(asset.history.length).toEqual(3);
+    const newFileHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    expect(newFileHistory.length).toEqual(3);
   });
 
   it('should be able to get an Asset of a specific commit', async function () {
-    const commitHash = asset.history.at(-1)?.hash;
+    const assetHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const commitHash = assetHistory.at(-1)?.hash;
 
     if (!commitHash) {
       throw new Error('No commit hash found');
@@ -120,8 +124,9 @@ describe('AssetService', function () {
   });
 
   it('should be able to get the same Asset from multiple commits', async function () {
-    const previousCommitHash = asset.history.at(-1)?.hash;
-    const currentCommitHash = asset.history.shift()?.hash;
+    const multiHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const previousCommitHash = multiHistory.at(-1)?.hash;
+    const currentCommitHash = multiHistory[0]?.hash;
 
     if (!previousCommitHash || !currentCommitHash) {
       throw new Error('No commit hash found');
@@ -208,7 +213,7 @@ describe('AssetService', function () {
     await core.assets.save({
       projectId: project.id,
       id: asset.id,
-      commitHash: asset.history.at(-1)?.hash,
+      commitHash: (await core.assets.history({ projectId: project.id, id: asset.id })).at(-1)?.hash,
       filePath: filePathToSaveToFromHistory,
     });
 

--- a/src/service/AssetService.test.ts
+++ b/src/service/AssetService.test.ts
@@ -35,7 +35,10 @@ describe('AssetService', function () {
     ).to.approximately(Math.floor(Date.now() / 1000), 5); // 5 seconds of delta allowed
     expect(asset.extension).toEqual('png');
     expect(asset.mimeType).toEqual('image/png');
-    const createHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const createHistory = await core.assets.history({
+      projectId: project.id,
+      id: asset.id,
+    });
     expect(createHistory.length).toEqual(1);
     expect(
       await Fs.pathExists(core.util.pathTo.assetFile(project.id, asset.id)),
@@ -70,7 +73,10 @@ describe('AssetService', function () {
     });
 
     expect(asset.description).toEqual('A 150x150 image of the text "elek.io"');
-    const updateHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const updateHistory = await core.assets.history({
+      projectId: project.id,
+      id: asset.id,
+    });
     expect(updateHistory.length).toEqual(2);
   });
 
@@ -84,12 +90,18 @@ describe('AssetService', function () {
 
     expect(asset.extension).toEqual('jpg');
     expect(asset.size).toEqual(1342);
-    const newFileHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const newFileHistory = await core.assets.history({
+      projectId: project.id,
+      id: asset.id,
+    });
     expect(newFileHistory.length).toEqual(3);
   });
 
   it('should be able to get an Asset of a specific commit', async function () {
-    const assetHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const assetHistory = await core.assets.history({
+      projectId: project.id,
+      id: asset.id,
+    });
     const commitHash = assetHistory.at(-1)?.hash;
 
     if (!commitHash) {
@@ -124,7 +136,10 @@ describe('AssetService', function () {
   });
 
   it('should be able to get the same Asset from multiple commits', async function () {
-    const multiHistory = await core.assets.history({ projectId: project.id, id: asset.id });
+    const multiHistory = await core.assets.history({
+      projectId: project.id,
+      id: asset.id,
+    });
     const previousCommitHash = multiHistory.at(-1)?.hash;
     const currentCommitHash = multiHistory[0]?.hash;
 
@@ -213,7 +228,9 @@ describe('AssetService', function () {
     await core.assets.save({
       projectId: project.id,
       id: asset.id,
-      commitHash: (await core.assets.history({ projectId: project.id, id: asset.id })).at(-1)?.hash,
+      commitHash: (
+        await core.assets.history({ projectId: project.id, id: asset.id })
+      ).at(-1)?.hash,
       filePath: filePathToSaveToFromHistory,
     });
 

--- a/src/service/AssetService.ts
+++ b/src/service/AssetService.ts
@@ -24,6 +24,9 @@ import {
   type PaginatedList,
   type ReadAssetProps,
   type UpdateAssetProps,
+  type AssetHistoryProps,
+  type GitCommit,
+  assetHistorySchema,
 } from '../schema/index.js';
 import { pathTo } from '../util/node.js';
 import { datetime, slug, uuid } from '../util/shared.js';
@@ -141,6 +144,17 @@ export class AssetService
 
       return this.toAsset(props.projectId, assetFile, props.commitHash);
     }
+  }
+
+  /**
+   * Returns the commit history of an Asset
+   */
+  public async history(props: AssetHistoryProps): Promise<GitCommit[]> {
+    assetHistorySchema.parse(props);
+
+    return this.gitService.log(pathTo.project(props.projectId), {
+      filePath: pathTo.assetFile(props.projectId, props.id),
+    });
   }
 
   /**
@@ -298,26 +312,19 @@ export class AssetService
    * @param projectId   The project's ID
    * @param assetFile   The AssetFile to convert
    */
-  private async toAsset(
+  private toAsset(
     projectId: string,
     assetFile: AssetFile,
     commitHash?: string
-  ): Promise<Asset> {
+  ): Asset {
     const assetPath = commitHash
       ? pathTo.tmpAsset(assetFile.id, commitHash, assetFile.extension)
       : pathTo.asset(projectId, assetFile.id, assetFile.extension);
 
-    const history = await this.gitService.log(pathTo.project(projectId), {
-      filePath: pathTo.assetFile(projectId, assetFile.id),
-    });
-
-    const asset: Asset = {
+    return {
       ...assetFile,
       absolutePath: assetPath,
-      history,
     };
-
-    return asset;
   }
 
   /**

--- a/src/service/AssetService.ts
+++ b/src/service/AssetService.ts
@@ -4,6 +4,7 @@ import type { SaveAssetProps } from '../schema/index.js';
 import {
   assetFileSchema,
   assetSchema,
+  migrateAssetSchema,
   countAssetsSchema,
   createAssetSchema,
   deleteAssetSchema,
@@ -42,10 +43,12 @@ export class AssetService
   extends AbstractCrudService
   implements CrudServiceWithListCount<Asset>
 {
+  private readonly coreVersion: string;
   private readonly jsonFileService: JsonFileService;
   private readonly gitService: GitService;
 
   constructor(
+    coreVersion: string,
     options: ElekIoCoreOptions,
     logService: LogService,
     jsonFileService: JsonFileService,
@@ -53,6 +56,7 @@ export class AssetService
   ) {
     super(serviceTypeSchema.enum.Asset, options, logService);
 
+    this.coreVersion = coreVersion;
     this.jsonFileService = jsonFileService;
     this.gitService = gitService;
   }
@@ -75,6 +79,7 @@ export class AssetService
       name: slug(props.name),
       objectType: 'asset',
       id,
+      coreVersion: this.coreVersion,
       created: datetime(),
       updated: null,
       extension: fileType.extension,
@@ -358,8 +363,10 @@ export class AssetService
    * Migrates an potentially outdated Asset file to the current schema
    */
   public migrate(potentiallyOutdatedAssetFile: unknown) {
-    // @todo
+    const loose = migrateAssetSchema.parse(potentiallyOutdatedAssetFile);
 
-    return assetFileSchema.parse(potentiallyOutdatedAssetFile);
+    loose.coreVersion = this.coreVersion;
+
+    return assetFileSchema.parse(loose);
   }
 }

--- a/src/service/AssetService.ts
+++ b/src/service/AssetService.ts
@@ -29,6 +29,7 @@ import {
   type GitCommit,
   assetHistorySchema,
 } from '../schema/index.js';
+import { applyMigrations, assetMigrations } from './migrations/index.js';
 import { pathTo } from '../util/node.js';
 import { datetime, slug, uuid } from '../util/shared.js';
 import { AbstractCrudService } from './AbstractCrudService.js';
@@ -364,9 +365,7 @@ export class AssetService
    */
   public migrate(potentiallyOutdatedAssetFile: unknown) {
     const loose = migrateAssetSchema.parse(potentiallyOutdatedAssetFile);
-
-    loose.coreVersion = this.coreVersion;
-
-    return assetFileSchema.parse(loose);
+    const migrated = applyMigrations(loose, assetMigrations, this.coreVersion);
+    return assetFileSchema.parse(migrated);
   }
 }

--- a/src/service/CollectionService.test.ts
+++ b/src/service/CollectionService.test.ts
@@ -1,8 +1,16 @@
 import Fs from 'fs-extra';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import core, { type Collection, type Project } from '../test/setup.js';
+import core, {
+  type Asset,
+  type Collection,
+  type Entry,
+  type Project,
+  uuid,
+} from '../test/setup.js';
 import {
+  createAsset,
   createCollection,
+  createEntry,
   createProject,
   ensureCleanGitStatus,
 } from '../test/util.js';
@@ -101,5 +109,505 @@ describe('CollectionService', function () {
         core.util.pathTo.collectionFile(project.id, collection.id)
       )
     ).toBe(false);
+  });
+});
+
+describe('CollectionService - resolveCollectionId', function () {
+  let project: Project & { destroy: () => Promise<void> };
+  let collection: Collection;
+
+  beforeAll(async function () {
+    project = await createProject();
+    collection = await createCollection(project.id);
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should resolve a collection by UUID', async function () {
+    const resolvedId = await core.collections.resolveCollectionId({
+      projectId: project.id,
+      idOrSlug: collection.id,
+    });
+
+    expect(resolvedId).toEqual(collection.id);
+  });
+
+  it('should resolve a collection by slug', async function () {
+    const resolvedId = await core.collections.resolveCollectionId({
+      projectId: project.id,
+      idOrSlug: collection.slug.plural,
+    });
+
+    expect(resolvedId).toEqual(collection.id);
+  });
+
+  it('should throw when resolving a non-existent identifier', async function () {
+    await expect(() =>
+      core.collections.resolveCollectionId({
+        projectId: project.id,
+        idOrSlug: 'non-existent-slug',
+      })
+    ).rejects.toThrow('Collection not found');
+  });
+
+  it('should throw when resolving a non-existent UUID', async function () {
+    const fakeUuid = uuid();
+    await expect(() =>
+      core.collections.resolveCollectionId({
+        projectId: project.id,
+        idOrSlug: fakeUuid,
+      })
+    ).rejects.toThrow('Collection not found');
+  });
+});
+
+describe('CollectionService - readBySlug', function () {
+  let project: Project & { destroy: () => Promise<void> };
+  let collection: Collection;
+
+  beforeAll(async function () {
+    project = await createProject();
+    collection = await createCollection(project.id);
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should read a collection by its slug', async function () {
+    const readCollection = await core.collections.readBySlug({
+      projectId: project.id,
+      slug: collection.slug.plural,
+    });
+
+    expect(readCollection.id).toEqual(collection.id);
+    expect(readCollection.slug.plural).toEqual(collection.slug.plural);
+  });
+
+  it('should throw when reading by a non-existent slug', async function () {
+    await expect(() =>
+      core.collections.readBySlug({
+        projectId: project.id,
+        slug: 'non-existent-slug',
+      })
+    ).rejects.toThrow('Collection not found');
+  });
+});
+
+describe('CollectionService - slug uniqueness', function () {
+  let project: Project & { destroy: () => Promise<void> };
+  let collection: Collection;
+
+  beforeAll(async function () {
+    project = await createProject();
+    collection = await createCollection(project.id);
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should reject creating a second collection with the same slug', async function () {
+    await expect(() =>
+      core.collections.create({
+        projectId: project.id,
+        icon: 'home',
+        name: {
+          singular: { en: 'Duplicate' },
+          plural: { en: 'Duplicates' },
+        },
+        slug: {
+          singular: 'duplicate',
+          plural: collection.slug.plural, // same as existing
+        },
+        description: { en: 'A duplicate slug collection' },
+        fieldDefinitions: [
+          {
+            id: uuid(),
+            slug: 'some-field',
+            valueType: 'string',
+            label: { en: 'Field' },
+            description: { en: 'Field' },
+            fieldType: 'text',
+            inputWidth: '12',
+            isDisabled: false,
+            isRequired: false,
+            isUnique: false,
+            min: null,
+            max: null,
+            defaultValue: null,
+          },
+        ],
+      })
+    ).rejects.toThrow('already in use');
+  });
+
+  it('should reject updating a collection slug to conflict with an existing one', async function () {
+    // Create a second collection with a different slug
+    const secondCollection = await core.collections.create({
+      projectId: project.id,
+      icon: 'home',
+      name: {
+        singular: { en: 'Other' },
+        plural: { en: 'Others' },
+      },
+      slug: {
+        singular: 'other',
+        plural: 'others',
+      },
+      description: { en: 'Another collection' },
+      fieldDefinitions: [
+        {
+          id: uuid(),
+          slug: 'other-field',
+          valueType: 'string',
+          label: { en: 'Field' },
+          description: { en: 'Field' },
+          fieldType: 'text',
+          inputWidth: '12',
+          isDisabled: false,
+          isRequired: false,
+          isUnique: false,
+          min: null,
+          max: null,
+          defaultValue: null,
+        },
+      ],
+    });
+
+    // Try to update it to use the first collection's slug
+    await expect(() =>
+      core.collections.update({
+        projectId: project.id,
+        ...secondCollection,
+        slug: {
+          singular: secondCollection.slug.singular,
+          plural: collection.slug.plural, // conflict
+        },
+      })
+    ).rejects.toThrow('already in use');
+
+    // Clean up
+    await core.collections.delete({
+      projectId: project.id,
+      id: secondCollection.id,
+    });
+  });
+});
+
+describe('CollectionService - fieldDefinition slug uniqueness', function () {
+  let project: Project & { destroy: () => Promise<void> };
+
+  beforeAll(async function () {
+    project = await createProject();
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should reject creating a collection with duplicate fieldDefinition slugs', async function () {
+    await expect(() =>
+      core.collections.create({
+        projectId: project.id,
+        icon: 'home',
+        name: {
+          singular: { en: 'Item' },
+          plural: { en: 'Items' },
+        },
+        slug: {
+          singular: 'item',
+          plural: 'items',
+        },
+        description: { en: 'Test' },
+        fieldDefinitions: [
+          {
+            id: uuid(),
+            slug: 'duplicate-slug',
+            valueType: 'string',
+            label: { en: 'Field 1' },
+            description: { en: 'Field 1' },
+            fieldType: 'text',
+            inputWidth: '12',
+            isDisabled: false,
+            isRequired: false,
+            isUnique: false,
+            min: null,
+            max: null,
+            defaultValue: null,
+          },
+          {
+            id: uuid(),
+            slug: 'duplicate-slug',
+            valueType: 'string',
+            label: { en: 'Field 2' },
+            description: { en: 'Field 2' },
+            fieldType: 'text',
+            inputWidth: '12',
+            isDisabled: false,
+            isRequired: false,
+            isUnique: false,
+            min: null,
+            max: null,
+            defaultValue: null,
+          },
+        ],
+      })
+    ).rejects.toThrow('Duplicate fieldDefinition slug');
+  });
+
+  it('should reject updating a collection with duplicate fieldDefinition slugs', async function () {
+    const collection = await core.collections.create({
+      projectId: project.id,
+      icon: 'home',
+      name: {
+        singular: { en: 'Widget' },
+        plural: { en: 'Widgets' },
+      },
+      slug: {
+        singular: 'widget',
+        plural: 'widgets',
+      },
+      description: { en: 'Test' },
+      fieldDefinitions: [
+        {
+          id: uuid(),
+          slug: 'field-a',
+          valueType: 'string',
+          label: { en: 'Field A' },
+          description: { en: 'Field A' },
+          fieldType: 'text',
+          inputWidth: '12',
+          isDisabled: false,
+          isRequired: false,
+          isUnique: false,
+          min: null,
+          max: null,
+          defaultValue: null,
+        },
+        {
+          id: uuid(),
+          slug: 'field-b',
+          valueType: 'string',
+          label: { en: 'Field B' },
+          description: { en: 'Field B' },
+          fieldType: 'text',
+          inputWidth: '12',
+          isDisabled: false,
+          isRequired: false,
+          isUnique: false,
+          min: null,
+          max: null,
+          defaultValue: null,
+        },
+      ],
+    });
+
+    // Rename field-b to field-a (duplicate)
+    const updatedFieldDefs = collection.fieldDefinitions.map((fd) => ({
+      ...fd,
+      slug: 'field-a',
+    }));
+
+    await expect(() =>
+      core.collections.update({
+        projectId: project.id,
+        ...collection,
+        fieldDefinitions: updatedFieldDefs,
+      })
+    ).rejects.toThrow('Duplicate fieldDefinition slug');
+
+    // Clean up
+    await core.collections.delete({
+      projectId: project.id,
+      id: collection.id,
+    });
+  });
+});
+
+describe('CollectionService - fieldDefinition slug rename cascade', function () {
+  let project: Project & { destroy: () => Promise<void> };
+  let asset: Asset;
+  let collection: Collection;
+  let entry: Entry;
+
+  beforeAll(async function () {
+    project = await createProject();
+    asset = await createAsset(project.id);
+    collection = await createCollection(project.id);
+    entry = await createEntry(project.id, collection.id, asset.id);
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should rename entry value keys when a fieldDefinition slug is renamed', async function () {
+    const oldSlugs = Object.keys(entry.values);
+    const targetFieldDef = collection.fieldDefinitions[0]!;
+    const oldSlug = targetFieldDef.slug;
+    const newSlug = 'renamed-field';
+
+    // Update the collection with a renamed field definition slug
+    const updatedFieldDefs = collection.fieldDefinitions.map((fd) => {
+      if (fd.id === targetFieldDef.id) {
+        return { ...fd, slug: newSlug };
+      }
+      return fd;
+    });
+
+    collection = await core.collections.update({
+      projectId: project.id,
+      ...collection,
+      fieldDefinitions: updatedFieldDefs,
+    });
+
+    // Read the entry and verify the value key was renamed
+    const updatedEntry = await core.entries.read({
+      projectId: project.id,
+      collectionId: collection.id,
+      id: entry.id,
+    });
+
+    expect(updatedEntry.values[newSlug]).toBeDefined();
+    expect(updatedEntry.values[oldSlug]).toBeUndefined();
+
+    // All other keys should still be present
+    const newSlugs = Object.keys(updatedEntry.values);
+    expect(newSlugs.length).toEqual(oldSlugs.length);
+
+    entry = updatedEntry;
+  });
+
+  it('should rename multiple field definition slugs simultaneously', async function () {
+    // Rename two field definitions at once
+    const firstFd = collection.fieldDefinitions[0]!;
+    const secondFd = collection.fieldDefinitions[1]!;
+    const newSlug1 = 'multi-rename-a';
+    const newSlug2 = 'multi-rename-b';
+
+    const updatedFieldDefs = collection.fieldDefinitions.map((fd) => {
+      if (fd.id === firstFd.id) return { ...fd, slug: newSlug1 };
+      if (fd.id === secondFd.id) return { ...fd, slug: newSlug2 };
+      return fd;
+    });
+
+    collection = await core.collections.update({
+      projectId: project.id,
+      ...collection,
+      fieldDefinitions: updatedFieldDefs,
+    });
+
+    const updatedEntry = await core.entries.read({
+      projectId: project.id,
+      collectionId: collection.id,
+      id: entry.id,
+    });
+
+    expect(updatedEntry.values[newSlug1]).toBeDefined();
+    expect(updatedEntry.values[newSlug2]).toBeDefined();
+    expect(updatedEntry.values[firstFd.slug]).toBeUndefined();
+    expect(updatedEntry.values[secondFd.slug]).toBeUndefined();
+
+    entry = updatedEntry;
+  });
+});
+
+describe('CollectionService - collection index', function () {
+  let project: Project & { destroy: () => Promise<void> };
+  let collection: Collection;
+
+  beforeAll(async function () {
+    project = await createProject();
+    collection = await createCollection(project.id);
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should create an index file on disk after collection creation', async function () {
+    const indexPath = core.util.pathTo.collectionIndex(project.id);
+    expect(await Fs.pathExists(indexPath)).toBe(true);
+
+    const indexContent = JSON.parse(
+      await Fs.readFile(indexPath, { encoding: 'utf8' })
+    ) as Record<string, string>;
+    expect(indexContent[collection.id]).toEqual(collection.slug.plural);
+  });
+
+  it('should remove collection from index after deletion', async function () {
+    const tempCollection = await core.collections.create({
+      projectId: project.id,
+      icon: 'home',
+      name: {
+        singular: { en: 'Temp' },
+        plural: { en: 'Temps' },
+      },
+      slug: {
+        singular: 'temp',
+        plural: 'temps',
+      },
+      description: { en: 'Temporary' },
+      fieldDefinitions: [
+        {
+          id: uuid(),
+          slug: 'temp-field',
+          valueType: 'string',
+          label: { en: 'Field' },
+          description: { en: 'Field' },
+          fieldType: 'text',
+          inputWidth: '12',
+          isDisabled: false,
+          isRequired: false,
+          isUnique: false,
+          min: null,
+          max: null,
+          defaultValue: null,
+        },
+      ],
+    });
+
+    const indexPath = core.util.pathTo.collectionIndex(project.id);
+    let indexContent = JSON.parse(
+      await Fs.readFile(indexPath, { encoding: 'utf8' })
+    ) as Record<string, string>;
+    expect(indexContent[tempCollection.id]).toEqual('temps');
+
+    await core.collections.delete({
+      projectId: project.id,
+      id: tempCollection.id,
+    });
+
+    indexContent = JSON.parse(
+      await Fs.readFile(indexPath, { encoding: 'utf8' })
+    ) as Record<string, string>;
+    expect(indexContent[tempCollection.id]).toBeUndefined();
   });
 });

--- a/src/service/CollectionService.test.ts
+++ b/src/service/CollectionService.test.ts
@@ -62,10 +62,14 @@ describe('CollectionService', function () {
   });
 
   it('should be able to get a Collection of a specific commit', async function () {
+    const history = await core.collections.history({
+      projectId: project.id,
+      id: collection.id,
+    });
     const collectionFromHistory = await core.collections.read({
       projectId: project.id,
       id: collection.id,
-      commitHash: collection.history.at(-1)?.hash,
+      commitHash: history.at(-1)?.hash,
     });
 
     expect(collectionFromHistory.description.en).toEqual(

--- a/src/service/CollectionService.ts
+++ b/src/service/CollectionService.ts
@@ -428,9 +428,7 @@ export class CollectionService
    * @param projectId   The project's ID
    * @param collectionFile   The CollectionFile to convert
    */
-  private toCollection(
-    collectionFile: CollectionFile
-  ): Collection {
+  private toCollection(collectionFile: CollectionFile): Collection {
     return {
       ...collectionFile,
     };

--- a/src/service/CollectionService.ts
+++ b/src/service/CollectionService.ts
@@ -2,6 +2,7 @@ import Fs from 'fs-extra';
 import {
   collectionFileSchema,
   countCollectionsSchema,
+  migrateCollectionSchema,
   createCollectionSchema,
   deleteCollectionSchema,
   entryFileSchema,
@@ -43,6 +44,7 @@ export class CollectionService
   extends AbstractCrudService
   implements CrudServiceWithListCount<Collection>
 {
+  private coreVersion: string;
   private jsonFileService: JsonFileService;
   private gitService: GitService;
 
@@ -52,6 +54,7 @@ export class CollectionService
   private rebuildPromise: Map<string, Promise<CollectionIndex>> = new Map();
 
   constructor(
+    coreVersion: string,
     options: ElekIoCoreOptions,
     logService: LogService,
     jsonFileService: JsonFileService,
@@ -59,6 +62,7 @@ export class CollectionService
   ) {
     super(serviceTypeSchema.enum.Collection, options, logService);
 
+    this.coreVersion = coreVersion;
     this.jsonFileService = jsonFileService;
     this.gitService = gitService;
   }
@@ -132,6 +136,7 @@ export class CollectionService
       ...props,
       objectType: 'collection',
       id,
+      coreVersion: this.coreVersion,
       slug: {
         singular: slug(props.slug.singular),
         plural: slugPlural,
@@ -417,9 +422,11 @@ export class CollectionService
    * Migrates an potentially outdated Collection file to the current schema
    */
   public migrate(potentiallyOutdatedCollectionFile: unknown) {
-    // @todo
+    const loose = migrateCollectionSchema.parse(potentiallyOutdatedCollectionFile);
 
-    return collectionFileSchema.parse(potentiallyOutdatedCollectionFile);
+    loose.coreVersion = this.coreVersion;
+
+    return collectionFileSchema.parse(loose);
   }
 
   /**

--- a/src/service/CollectionService.ts
+++ b/src/service/CollectionService.ts
@@ -4,13 +4,17 @@ import {
   countCollectionsSchema,
   createCollectionSchema,
   deleteCollectionSchema,
+  entryFileSchema,
   listCollectionsSchema,
   objectTypeSchema,
+  type ReadBySlugCollectionProps,
   readCollectionSchema,
   serviceTypeSchema,
   updateCollectionSchema,
+  uuidSchema,
   type Collection,
   type CollectionFile,
+  type CollectionIndex,
   type CountCollectionsProps,
   type CreateCollectionProps,
   type CrudServiceWithListCount,
@@ -20,8 +24,9 @@ import {
   type PaginatedList,
   type ReadCollectionProps,
   type UpdateCollectionProps,
+  type ResolveCollectionIdProps,
 } from '../schema/index.js';
-import { pathTo } from '../util/node.js';
+import { folders, pathTo } from '../util/node.js';
 import { datetime, slug, uuid } from '../util/shared.js';
 import { AbstractCrudService } from './AbstractCrudService.js';
 import type { GitService } from './GitService.js';
@@ -38,6 +43,11 @@ export class CollectionService
   private jsonFileService: JsonFileService;
   private gitService: GitService;
 
+  /** In-memory cache for collection indices, keyed by projectId */
+  private cachedIndex: Map<string, CollectionIndex> = new Map();
+  /** Promise deduplication for concurrent rebuilds, keyed by projectId */
+  private rebuildPromise: Map<string, Promise<CollectionIndex>> = new Map();
+
   constructor(
     options: ElekIoCoreOptions,
     logService: LogService,
@@ -51,15 +61,69 @@ export class CollectionService
   }
 
   /**
+   * Resolves a UUID-or-slug string to a collection UUID.
+   *
+   * If the input matches UUID format, verifies the folder exists on disk first.
+   * If the folder doesn't exist, falls back to slug lookup.
+   * Otherwise, looks up via the index.
+   */
+  public async resolveCollectionId(
+    props: ResolveCollectionIdProps
+  ): Promise<string> {
+    // Check if it looks like a UUID
+    if (uuidSchema.safeParse(props.idOrSlug).success) {
+      // Verify the UUID folder exists on disk
+      const collectionPath = pathTo.collection(props.projectId, props.idOrSlug);
+      if (await Fs.pathExists(collectionPath)) {
+        return props.idOrSlug;
+      }
+      // Fall through to slug lookup
+    }
+
+    // Look up by slug
+    const index = await this.getIndex(props.projectId);
+    for (const [uuid, slugValue] of Object.entries(index)) {
+      if (slugValue === props.idOrSlug) {
+        return uuid;
+      }
+    }
+
+    // Rebuild and retry once (handles stale cache)
+    this.cachedIndex.delete(props.projectId);
+    const freshIndex = await this.getIndex(props.projectId);
+    for (const [uuid, slugValue] of Object.entries(freshIndex)) {
+      if (slugValue === props.idOrSlug) {
+        return uuid;
+      }
+    }
+
+    throw new Error(
+      `Collection not found: "${props.idOrSlug}" does not match any collection UUID or slug`
+    );
+  }
+
+  /**
    * Creates a new Collection
    */
   public async create(props: CreateCollectionProps): Promise<Collection> {
     createCollectionSchema.parse(props);
 
+    this.validateFieldDefinitionSlugUniqueness(props.fieldDefinitions);
+
     const id = uuid();
     const projectPath = pathTo.project(props.projectId);
     const collectionPath = pathTo.collection(props.projectId, id);
     const collectionFilePath = pathTo.collectionFile(props.projectId, id);
+
+    const slugPlural = slug(props.slug.plural);
+
+    // Enforce collection slug uniqueness via index
+    const index = await this.getIndex(props.projectId);
+    if (Object.values(index).includes(slugPlural)) {
+      throw new Error(
+        `Collection slug "${slugPlural}" is already in use by another collection`
+      );
+    }
 
     const collectionFile: CollectionFile = {
       ...props,
@@ -67,7 +131,7 @@ export class CollectionService
       id,
       slug: {
         singular: slug(props.slug.singular),
-        plural: slug(props.slug.plural),
+        plural: slugPlural,
       },
       created: datetime(),
       updated: null,
@@ -84,6 +148,10 @@ export class CollectionService
       method: 'create',
       reference: { objectType: 'collection', id },
     });
+
+    // Update the index (not git-tracked)
+    index[id] = slugPlural;
+    await this.writeIndex(props.projectId, index);
 
     return this.toCollection(props.projectId, collectionFile);
   }
@@ -119,17 +187,31 @@ export class CollectionService
   }
 
   /**
+   * Reads a Collection by its slug
+   */
+  public async readBySlug(
+    props: ReadBySlugCollectionProps
+  ): Promise<Collection> {
+    const id = await this.resolveCollectionId({
+      projectId: props.projectId,
+      idOrSlug: props.slug,
+    });
+    return this.read({
+      projectId: props.projectId,
+      id,
+      commitHash: props.commitHash,
+    });
+  }
+
+  /**
    * Updates given Collection
    *
-   * @todo finish implementing checks for FieldDefinitions and extract methods
-   *
-   * @param projectId   Project ID of the collection to update
-   * @param collection  Collection to write to disk
-   * @returns           An object containing information about the actions needed to be taken,
-   *                    before given update can be executed or void if the update was executed successfully
+   * Handles fieldDefinition slug rename cascade and collection slug uniqueness.
    */
   public async update(props: UpdateCollectionProps): Promise<Collection> {
     updateCollectionSchema.parse(props);
+
+    this.validateFieldDefinitionSlugUniqueness(props.fieldDefinitions);
 
     const projectPath = pathTo.project(props.projectId);
     const collectionFilePath = pathTo.collectionFile(props.projectId, props.id);
@@ -141,158 +223,95 @@ export class CollectionService
       updated: datetime(),
     };
 
-    // @todo Collection Service has to check if any of the updated fieldDefinitions do not validate against the used Fields in each CollectionItem of the Collection
-    // and return a list of mismatches, so the user can choose what to do in the UI / a wizard
-    // For that:
-    // - Iterate over all CollectionItems inside Collection
-    // - Create an array with all FieldReferences of those CollectionItems
-    // - Load all Fields by those references and check if the Field still complies with the new definition
+    // FieldDefinition slug rename cascade:
+    // Match old and new fieldDefinitions by UUID to detect slug renames
+    const oldFieldDefs = prevCollectionFile.fieldDefinitions;
+    const newFieldDefs = props.fieldDefinitions;
+    const slugRenames: Array<{ oldSlug: string; newSlug: string }> = [];
 
-    // const result: CollectionUpdateResult = {
-    //   create: [],
-    //   update: [],
-    //   delete: [],
-    // };
+    const oldByUuid = new Map(oldFieldDefs.map((fd) => [fd.id, fd]));
+    for (const newFd of newFieldDefs) {
+      const oldFd = oldByUuid.get(newFd.id);
+      if (oldFd && oldFd.slug !== newFd.slug) {
+        slugRenames.push({ oldSlug: oldFd.slug, newSlug: newFd.slug });
+      }
+    }
 
-    // const currentCollection = await this.read(props);
-    // Iterate over all FieldDefinitions and check each for changes
-    // for (let index = 0; index < collection.fieldDefinitions.length; index++) {
-    //   const nextFieldDefinition = collection.fieldDefinitions[index];
-    //   if (!nextFieldDefinition) {
-    //     throw new Error('Could not find any field definition');
-    //   }
-    //   // Get the correct FieldDefinition by ID
-    //   const currentFieldDefinition = currentCollection.fieldDefinitions.find(
-    //     (current) => {
-    //       return current.id === nextFieldDefinition.id;
-    //     }
-    //   );
-    //   if (currentFieldDefinition) {
-    //     if (
-    //       currentFieldDefinition.isRequired === false &&
-    //       nextFieldDefinition.isRequired === true
-    //     ) {
-    //       // Case 1.
-    //       // A FieldDefinition was not required to be filled, but is now
-    //       // -> Check if all CollectionItems have a FieldReference to this definition (if not create)
-    //       // -> Check all values of referenced fields of this definition for null (if not update)
-    //       // -> If the value is null, this is a violation
-    //       const collectionItems = (
-    //         await this.collectionItemService.list(
-    //           projectId,
-    //           collection.id,
-    //           undefined,
-    //           undefined,
-    //           0,
-    //           0
-    //         )
-    //       ).list;
-    //       for (let index = 0; index < collectionItems.length; index++) {
-    //         const collectionItem = collectionItems[index];
-    //         if (!collectionItem) {
-    //           throw new Error('Blaa');
-    //         }
-    //         const fieldReference = collectionItem.fieldReferences.find(
-    //           (fieldReference) => {
-    //             return (
-    //               fieldReference.fieldDefinitionId === nextFieldDefinition.id
-    //             );
-    //           }
-    //         );
-    //         if (!fieldReference) {
-    //           result.create.push({
-    //             violation: Violation.FIELD_REQUIRED_BUT_UNDEFINED,
-    //             collectionItem,
-    //             fieldDefinition: nextFieldDefinition,
-    //           });
-    //         } else {
-    //           const field = await this.fieldService.read(
-    //             projectId,
-    //             fieldReference.field.id,
-    //             fieldReference.field.language
-    //           );
-    //           if (field.value === null) {
-    //             result.update.push({
-    //               violation: Violation.FIELD_VALUE_REQUIRED_BUT_NULL,
-    //               collectionItem,
-    //               fieldReference,
-    //             });
-    //           }
-    //         }
-    //       }
-    //     }
-    //     if (
-    //       currentFieldDefinition.isUnique !== nextFieldDefinition.isUnique &&
-    //       nextFieldDefinition.isUnique === true
-    //     ) {
-    //       // Case 2.
-    //       // A FieldDefinition was not required to be unique, but is now
-    //       // -> Check all current values of referenced fields
-    //       // -> If a value is not unique, this is a violation
-    //       // const fieldReferences = await this.collectionItemService.getAllFieldReferences(project, currentCollection, currentFieldDefinition.id);
-    //       // const fields = await this.fieldService.readAll(project, fieldReferences);
-    //       // const duplicates = getDuplicates(fields, 'value');
-    //       // for (let index = 0; index < duplicates.length; index++) {
-    //       //   const duplicate = duplicates[index];
-    //       //   result.update.push({
-    //       //     violation: Violation.FIELD_VALUE_NOT_UNIQUE,
-    //       //     collectionItem: ,
-    //       //     fieldReference
-    //       //   });
-    //       // }
-    //     }
-    //     if (
-    //       isEqual(currentFieldDefinition.input, nextFieldDefinition.input) ===
-    //       false
-    //     ) {
-    //       // Case 3.
-    //       // A FieldDefinition has a new input specification
-    //       // -> Check if this input is valid for given FieldType
-    //       // -> If not, this is a violation
-    //     }
-    //   } else {
-    //     // It's a new FieldDefinition that was not existing before
-    //     if (nextFieldDefinition.isRequired) {
-    //       // Case 4.
-    //       // A FieldDefinition is new and a field (with value) required
-    //       // -> The user needs to add a field reference (either through a new or existing field)
-    //       // for every CollectionItem of this Collection
-    //       const collectionItems = (
-    //         await this.collectionItemService.list(
-    //           projectId,
-    //           collection.id,
-    //           undefined,
-    //           undefined,
-    //           0,
-    //           0
-    //         )
-    //       ).list;
-    //       collectionItems.forEach((collectionItem) => {
-    //         result.create.push({
-    //           violation: Violation.FIELD_REQUIRED_BUT_UNDEFINED,
-    //           collectionItem,
-    //           fieldDefinition: nextFieldDefinition,
-    //         });
-    //       });
-    //     }
-    //   }
-    // }
+    const filesToGitAdd: string[] = [collectionFilePath];
 
-    // // Return early to notify the user of changes he has to do before this update is working
-    // if (
-    //   result.create.length !== 0 ||
-    //   result.update.length !== 0 ||
-    //   result.delete.length !== 0
-    // ) {
-    //   return result;
-    // }
+    if (slugRenames.length > 0) {
+      // Read all entries and rewrite their values record keys
+      const entriesPath = pathTo.entries(props.projectId, props.id);
+      if (await Fs.pathExists(entriesPath)) {
+        const entryFiles = (await Fs.readdir(entriesPath)).filter(
+          (f) => f.endsWith('.json') && f !== 'collection.json'
+        );
+
+        for (const entryFileName of entryFiles) {
+          const entryFilePath = pathTo.entryFile(
+            props.projectId,
+            props.id,
+            entryFileName.replace('.json', '')
+          );
+
+          try {
+            const entryFile = await this.jsonFileService.read(
+              entryFilePath,
+              entryFileSchema
+            );
+
+            let changed = false;
+            const newValues: Record<string, unknown> = { ...entryFile.values };
+
+            for (const { oldSlug, newSlug } of slugRenames) {
+              if (oldSlug in newValues) {
+                newValues[newSlug] = newValues[oldSlug];
+                delete newValues[oldSlug];
+                changed = true;
+              }
+            }
+
+            if (changed) {
+              const updatedEntryFile = { ...entryFile, values: newValues };
+              await this.jsonFileService.update(
+                updatedEntryFile,
+                entryFilePath,
+                entryFileSchema
+              );
+              filesToGitAdd.push(entryFilePath);
+            }
+          } catch (error) {
+            this.logService.warn({
+              source: 'core',
+              message: `Failed to update entry "${entryFileName}" during slug rename cascade: ${error instanceof Error ? error.message : String(error)}`,
+            });
+          }
+        }
+      }
+    }
+
+    // If collection slug.plural changed, enforce uniqueness
+    const newSlugPlural = slug(props.slug.plural);
+    if (prevCollectionFile.slug.plural !== newSlugPlural) {
+      const index = await this.getIndex(props.projectId);
+      const existingUuid = Object.entries(index).find(
+        ([, s]) => s === newSlugPlural
+      );
+      if (existingUuid && existingUuid[0] !== props.id) {
+        throw new Error(
+          `Collection slug "${newSlugPlural}" is already in use by another collection`
+        );
+      }
+      index[props.id] = newSlugPlural;
+      await this.writeIndex(props.projectId, index);
+    }
 
     await this.jsonFileService.update(
       collectionFile,
       collectionFilePath,
       collectionFileSchema
     );
-    await this.gitService.add(projectPath, [collectionFilePath]);
+    await this.gitService.add(projectPath, filesToGitAdd);
     await this.gitService.commit(projectPath, {
       method: 'update',
       reference: { objectType: 'collection', id: collectionFile.id },
@@ -302,7 +321,7 @@ export class CollectionService
   }
 
   /**
-   * Deletes given Collection (folder), including it's items
+   * Deletes given Collection (folder), including it's Entries
    *
    * The Fields that Collection used are not deleted.
    */
@@ -318,6 +337,11 @@ export class CollectionService
       method: 'delete',
       reference: { objectType: 'collection', id: props.id },
     });
+
+    // Remove from index
+    const index = await this.getIndex(props.projectId);
+    delete index[props.id];
+    await this.writeIndex(props.projectId, index);
   }
 
   public async list(
@@ -404,5 +428,91 @@ export class CollectionService
     };
 
     return collection;
+  }
+
+  /**
+   * Gets the collection index, rebuilding from disk if not cached
+   */
+  private async getIndex(projectId: string): Promise<CollectionIndex> {
+    const cached = this.cachedIndex.get(projectId);
+    if (cached) return cached;
+    const pending = this.rebuildPromise.get(projectId);
+    if (pending) return pending;
+    const promise = this.rebuildIndex(projectId);
+    this.rebuildPromise.set(projectId, promise);
+    const result = await promise;
+    this.cachedIndex.set(projectId, result);
+    this.rebuildPromise.delete(projectId);
+    return result;
+  }
+
+  /**
+   * Writes the index file atomically and updates cache
+   */
+  private async writeIndex(
+    projectId: string,
+    index: CollectionIndex
+  ): Promise<void> {
+    const indexPath = pathTo.collectionIndex(projectId);
+    await Fs.writeFile(indexPath, JSON.stringify(index, null, 2), {
+      encoding: 'utf8',
+    });
+    this.cachedIndex.set(projectId, index);
+  }
+
+  /**
+   * Rebuilds the index by scanning all collection folders
+   */
+  private async rebuildIndex(projectId: string): Promise<CollectionIndex> {
+    this.logService.info({
+      source: 'core',
+      message: `Rebuilding Collection index for Project "${projectId}"`,
+    });
+
+    const index: CollectionIndex = {};
+    const collectionsPath = pathTo.collections(projectId);
+    const collectionFolders = await folders(collectionsPath);
+
+    for (const folder of collectionFolders) {
+      // Skip the index.json file entry if it shows up
+      if (!uuidSchema.safeParse(folder.name).success) continue;
+
+      try {
+        const collectionFilePath = pathTo.collectionFile(
+          projectId,
+          folder.name
+        );
+        const collectionFile = await this.jsonFileService.read(
+          collectionFilePath,
+          collectionFileSchema
+        );
+        index[collectionFile.id] = collectionFile.slug.plural;
+      } catch (error) {
+        this.logService.warn({
+          source: 'core',
+          message: `Skipping collection folder "${folder.name}" during index rebuild: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    }
+
+    await this.writeIndex(projectId, index);
+    return index;
+  }
+
+  /**
+   * Validates that no two fieldDefinitions share the same slug
+   */
+  private validateFieldDefinitionSlugUniqueness(
+    fieldDefinitions: { slug: string }[]
+  ): void {
+    const seen = new Set<string>();
+    for (const fd of fieldDefinitions) {
+      if (seen.has(fd.slug)) {
+        throw new Error(
+          `Duplicate fieldDefinition slug "${fd.slug}": each fieldDefinition within a collection must have a unique slug`
+        );
+      }
+      seen.add(fd.slug);
+    }
   }
 }

--- a/src/service/CollectionService.ts
+++ b/src/service/CollectionService.ts
@@ -30,6 +30,7 @@ import {
   type GitCommit,
   collectionHistorySchema,
 } from '../schema/index.js';
+import { applyMigrations, collectionMigrations } from './migrations/index.js';
 import { folders, pathTo } from '../util/node.js';
 import { datetime, slug, uuid } from '../util/shared.js';
 import { AbstractCrudService } from './AbstractCrudService.js';
@@ -423,10 +424,8 @@ export class CollectionService
    */
   public migrate(potentiallyOutdatedCollectionFile: unknown) {
     const loose = migrateCollectionSchema.parse(potentiallyOutdatedCollectionFile);
-
-    loose.coreVersion = this.coreVersion;
-
-    return collectionFileSchema.parse(loose);
+    const migrated = applyMigrations(loose, collectionMigrations, this.coreVersion);
+    return collectionFileSchema.parse(migrated);
   }
 
   /**

--- a/src/service/CollectionService.ts
+++ b/src/service/CollectionService.ts
@@ -25,6 +25,9 @@ import {
   type ReadCollectionProps,
   type UpdateCollectionProps,
   type ResolveCollectionIdProps,
+  type CollectionHistoryProps,
+  type GitCommit,
+  collectionHistorySchema,
 } from '../schema/index.js';
 import { folders, pathTo } from '../util/node.js';
 import { datetime, slug, uuid } from '../util/shared.js';
@@ -153,7 +156,7 @@ export class CollectionService
     index[id] = slugPlural;
     await this.writeIndex(props.projectId, index);
 
-    return this.toCollection(props.projectId, collectionFile);
+    return this.toCollection(collectionFile);
   }
 
   /**
@@ -170,7 +173,7 @@ export class CollectionService
         collectionFileSchema
       );
 
-      return this.toCollection(props.projectId, collectionFile);
+      return this.toCollection(collectionFile);
     } else {
       const collectionFile = this.migrate(
         JSON.parse(
@@ -182,7 +185,7 @@ export class CollectionService
         )
       );
 
-      return this.toCollection(props.projectId, collectionFile);
+      return this.toCollection(collectionFile);
     }
   }
 
@@ -200,6 +203,17 @@ export class CollectionService
       projectId: props.projectId,
       id,
       commitHash: props.commitHash,
+    });
+  }
+
+  /**
+   * Returns the commit history of a Collection
+   */
+  public async history(props: CollectionHistoryProps): Promise<GitCommit[]> {
+    collectionHistorySchema.parse(props);
+
+    return this.gitService.log(pathTo.project(props.projectId), {
+      filePath: pathTo.collectionFile(props.projectId, props.id),
     });
   }
 
@@ -317,7 +331,7 @@ export class CollectionService
       reference: { objectType: 'collection', id: collectionFile.id },
     });
 
-    return this.toCollection(props.projectId, collectionFile);
+    return this.toCollection(collectionFile);
   }
 
   /**
@@ -414,20 +428,12 @@ export class CollectionService
    * @param projectId   The project's ID
    * @param collectionFile   The CollectionFile to convert
    */
-  private async toCollection(
-    projectId: string,
+  private toCollection(
     collectionFile: CollectionFile
-  ): Promise<Collection> {
-    const history = await this.gitService.log(pathTo.project(projectId), {
-      filePath: pathTo.collectionFile(projectId, collectionFile.id),
-    });
-
-    const collection: Collection = {
+  ): Collection {
+    return {
       ...collectionFile,
-      history,
     };
-
-    return collection;
   }
 
   /**

--- a/src/service/CollectionService.ts
+++ b/src/service/CollectionService.ts
@@ -423,8 +423,14 @@ export class CollectionService
    * Migrates an potentially outdated Collection file to the current schema
    */
   public migrate(potentiallyOutdatedCollectionFile: unknown) {
-    const loose = migrateCollectionSchema.parse(potentiallyOutdatedCollectionFile);
-    const migrated = applyMigrations(loose, collectionMigrations, this.coreVersion);
+    const loose = migrateCollectionSchema.parse(
+      potentiallyOutdatedCollectionFile
+    );
+    const migrated = applyMigrations(
+      loose,
+      collectionMigrations,
+      this.coreVersion
+    );
     return collectionFileSchema.parse(migrated);
   }
 

--- a/src/service/EntryService.test.ts
+++ b/src/service/EntryService.test.ts
@@ -115,11 +115,16 @@ describe('EntryService', function () {
   });
 
   it('should be able to get an Entry of a specific commit', async function () {
+    const history = await core.entries.history({
+      projectId: project.id,
+      collectionId: collection.id,
+      id: entry.id,
+    });
     const entryFromHistory = await core.entries.read({
       projectId: project.id,
       collectionId: collection.id,
       id: entry.id,
-      commitHash: entry.history.at(-1)?.hash,
+      commitHash: history.at(-1)?.hash,
     });
 
     expect(Object.keys(entryFromHistory.values).length).toEqual(3);

--- a/src/service/EntryService.test.ts
+++ b/src/service/EntryService.test.ts
@@ -65,22 +65,22 @@ describe('EntryService', function () {
         projectId: project.id,
         collectionId: collection.id,
         id: entry.id,
-        values: [],
+        values: {},
       })
     ).rejects.toThrow();
   });
 
   it('should fail to update an Entry with values not matching their fieldDefinitions', async function () {
-    const changedValue: Value = {
-      ...(entry.values[0] as Value),
-      valueType: 'number',
-      content: { en: 123 },
+    const slugs = Object.keys(entry.values);
+    const firstSlug = slugs[0]!;
+    const values: Record<string, Value> = {
+      ...entry.values,
+      [firstSlug]: {
+        ...entry.values[firstSlug]!,
+        valueType: 'number',
+        content: { en: 123 },
+      },
     };
-    const values: Value[] = [
-      changedValue,
-      entry.values[1] as Value,
-      entry.values[2] as Value,
-    ];
 
     await expect(() =>
       core.entries.update({
@@ -93,16 +93,16 @@ describe('EntryService', function () {
   });
 
   it('should be able to update an Entry with values that match the Collections fieldDefinitions', async function () {
-    const changedValue: Value = {
-      ...(entry.values[0] as Value),
-      valueType: 'string',
-      content: { en: 'Changed Text' },
+    const slugs = Object.keys(entry.values);
+    const firstSlug = slugs[0]!;
+    const values: Record<string, Value> = {
+      ...entry.values,
+      [firstSlug]: {
+        ...entry.values[firstSlug]!,
+        valueType: 'string',
+        content: { en: 'Changed Text' },
+      },
     };
-    const values: Value[] = [
-      changedValue,
-      entry.values[1] as Value,
-      entry.values[2] as Value,
-    ];
 
     entry = await core.entries.update({
       projectId: project.id,
@@ -122,7 +122,7 @@ describe('EntryService', function () {
       commitHash: entry.history.at(-1)?.hash,
     });
 
-    expect(entryFromHistory.values.length).toEqual(3);
+    expect(Object.keys(entryFromHistory.values).length).toEqual(3);
   });
 
   it('should be able to list all Entries', async function () {

--- a/src/service/EntryService.ts
+++ b/src/service/EntryService.ts
@@ -22,6 +22,9 @@ import {
   type ListEntriesProps,
   type ReadEntryProps,
   type UpdateEntryProps,
+  type EntryHistoryProps,
+  type GitCommit,
+  entryHistorySchema,
 } from '../schema/index.js';
 import { pathTo } from '../util/node.js';
 import { datetime, uuid } from '../util/shared.js';
@@ -85,11 +88,7 @@ export class EntryService
       updated: null,
     };
 
-    const entry = await this.toEntry(
-      props.projectId,
-      props.collectionId,
-      entryFile
-    );
+    const entry = this.toEntry(entryFile);
 
     // Validate all Values against their Field Definitions
     const createEntrySchemaFromFieldDefinitions =
@@ -128,7 +127,7 @@ export class EntryService
         entryFileSchema
       );
 
-      return this.toEntry(props.projectId, props.collectionId, entryFile);
+      return this.toEntry(entryFile);
     } else {
       const entryFile = this.migrate(
         JSON.parse(
@@ -140,8 +139,19 @@ export class EntryService
         )
       );
 
-      return this.toEntry(props.projectId, props.collectionId, entryFile);
+      return this.toEntry(entryFile);
     }
+  }
+
+  /**
+   * Returns the commit history of an Entry
+   */
+  public async history(props: EntryHistoryProps): Promise<GitCommit[]> {
+    entryHistorySchema.parse(props);
+
+    return this.gitService.log(pathTo.project(props.projectId), {
+      filePath: pathTo.entryFile(props.projectId, props.collectionId, props.id),
+    });
   }
 
   /**
@@ -173,11 +183,7 @@ export class EntryService
       updated: datetime(),
     };
 
-    const entry = await this.toEntry(
-      props.projectId,
-      props.collectionId,
-      entryFile
-    );
+    const entry = this.toEntry(entryFile);
 
     // Validate all Values against their Field Definitions
     const updateEntrySchemaFromFieldDefinitions =
@@ -293,18 +299,9 @@ export class EntryService
   /**
    * Creates an Entry from given EntryFile by resolving it's Values
    */
-  private async toEntry(
-    projectId: string,
-    collectionId: string,
-    entryFile: EntryFile
-  ): Promise<Entry> {
-    const history = await this.gitService.log(pathTo.project(projectId), {
-      filePath: pathTo.entryFile(projectId, collectionId, entryFile.id),
-    });
-
+  private toEntry(entryFile: EntryFile): Entry {
     return {
       ...entryFile,
-      history,
     };
   }
 }

--- a/src/service/EntryService.ts
+++ b/src/service/EntryService.ts
@@ -27,6 +27,7 @@ import {
   type GitCommit,
   entryHistorySchema,
 } from '../schema/index.js';
+import { applyMigrations, entryMigrations } from './migrations/index.js';
 import { pathTo } from '../util/node.js';
 import { datetime, uuid } from '../util/shared.js';
 import { AbstractCrudService } from './AbstractCrudService.js';
@@ -297,10 +298,8 @@ export class EntryService
    */
   public migrate(potentiallyOutdatedEntryFile: unknown) {
     const loose = migrateEntrySchema.parse(potentiallyOutdatedEntryFile);
-
-    loose.coreVersion = this.coreVersion;
-
-    return entryFileSchema.parse(loose);
+    const migrated = applyMigrations(loose, entryMigrations, this.coreVersion);
+    return entryFileSchema.parse(migrated);
   }
 
   /**

--- a/src/service/EntryService.ts
+++ b/src/service/EntryService.ts
@@ -2,6 +2,7 @@ import Fs from 'fs-extra';
 import {
   countEntriesSchema,
   createEntrySchema,
+  migrateEntrySchema,
   deleteEntrySchema,
   entryFileSchema,
   entrySchema,
@@ -41,12 +42,14 @@ export class EntryService
   extends AbstractCrudService
   implements CrudServiceWithListCount<Entry>
 {
+  private coreVersion: string;
   private jsonFileService: JsonFileService;
   private gitService: GitService;
   private collectionService: CollectionService;
   // private sharedValueService: SharedValueService;
 
   constructor(
+    coreVersion: string,
     options: ElekIoCoreOptions,
     logService: LogService,
     jsonFileService: JsonFileService,
@@ -56,6 +59,7 @@ export class EntryService
   ) {
     super(serviceTypeSchema.enum.Entry, options, logService);
 
+    this.coreVersion = coreVersion;
     this.jsonFileService = jsonFileService;
     this.gitService = gitService;
     this.collectionService = collectionService;
@@ -83,6 +87,7 @@ export class EntryService
     const entryFile: EntryFile = {
       objectType: 'entry',
       id,
+      coreVersion: this.coreVersion,
       values: props.values,
       created: datetime(),
       updated: null,
@@ -291,9 +296,11 @@ export class EntryService
    * Migrates an potentially outdated Entry file to the current schema
    */
   public migrate(potentiallyOutdatedEntryFile: unknown) {
-    // @todo
+    const loose = migrateEntrySchema.parse(potentiallyOutdatedEntryFile);
 
-    return entryFileSchema.parse(potentiallyOutdatedEntryFile);
+    loose.coreVersion = this.coreVersion;
+
+    return entryFileSchema.parse(loose);
   }
 
   /**

--- a/src/service/GitService.ts
+++ b/src/service/GitService.ts
@@ -574,6 +574,54 @@ export class GitService {
     ).stdout;
   }
 
+  /**
+   * Lists directory entries at a specific commit
+   *
+   * Useful for discovering what files/folders existed at a past commit,
+   * e.g. to detect deleted collections when comparing branches.
+   *
+   * @see https://git-scm.com/docs/git-ls-tree
+   *
+   * @param path      Path to the repository
+   * @param treePath  Relative path within the repository to list
+   * @param commitRef Commit hash, branch name, or other git ref
+   */
+  public async listTreeAtCommit(
+    path: string,
+    treePath: string,
+    commitRef: string
+  ): Promise<string[]> {
+    const relativeTreePath = treePath.replace(`${path}${Path.sep}`, '');
+    const normalizedPath = relativeTreePath.split('\\').join('/');
+    const args = [
+      'ls-tree',
+      '--name-only',
+      commitRef,
+      `${normalizedPath}/`,
+    ];
+
+    try {
+      const result = await this.git(path, args);
+      return result.stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line !== '')
+        .map((entry) => {
+          // ls-tree returns paths relative to repo root like "collections/uuid"
+          // Extract just the last segment (the folder/file name)
+          const parts = entry.split('/');
+          return parts[parts.length - 1] || entry;
+        });
+    } catch (error) {
+      // If the path or ref doesn't exist (e.g. first release), return empty.
+      // GitError is thrown for non-zero exit codes from git commands.
+      if (error instanceof GitError) {
+        return [];
+      }
+      throw error;
+    }
+  }
+
   public refNameToTagName(refName: string) {
     const tagName = refName.replace('tag: ', '').trim();
 

--- a/src/service/GitService.ts
+++ b/src/service/GitService.ts
@@ -471,9 +471,20 @@ export class GitService {
       throw new NoCurrentUserError();
     }
 
+    const subject = `${message.method.charAt(0).toUpperCase() + message.method.slice(1)} ${message.reference.objectType} ${message.reference.id}`;
+    const trailers = [
+      `Method: ${message.method}`,
+      `Object-Type: ${message.reference.objectType}`,
+      `Object-Id: ${message.reference.id}`,
+    ];
+    if (message.reference.collectionId) {
+      trailers.push(`Collection-Id: ${message.reference.collectionId}`);
+    }
+    const fullMessage = `${subject}\n\n${trailers.join('\n')}`;
+
     const args = [
       'commit',
-      `--message=${JSON.stringify(message)}`,
+      `--message=${fullMessage}`,
       `--author=${user.name} <${user.email}>`,
     ];
     await this.git(path, args);
@@ -507,7 +518,18 @@ export class GitService {
       args = [...args, `--max-count=${options.limit}`];
     }
 
-    args = [...args, '--format=%H|%s|%an|%ae|%aI|%D'];
+    const format = [
+      '%H',
+      '%(trailers:key=Method,valueonly)',
+      '%(trailers:key=Object-Type,valueonly)',
+      '%(trailers:key=Object-Id,valueonly)',
+      '%(trailers:key=Collection-Id,valueonly)',
+      '%an',
+      '%ae',
+      '%aI',
+      '%D',
+    ].join('|');
+    args = [...args, `--format=${format}`];
 
     if (options?.filePath) {
       args = [...args, '--', options.filePath];
@@ -515,33 +537,42 @@ export class GitService {
 
     const result = await this.git(path, args);
 
-    const noEmptyLinesArr = result.stdout.split('\n').filter((line) => {
+    // Trailer values from %(trailers:key=...,valueonly) include trailing newlines.
+    // Collapsing "\n|" into "|" rejoins the pipe-delimited fields into single lines.
+    const cleaned = result.stdout.replace(/\n\|/g, '|');
+
+    const noEmptyLinesArr = cleaned.split('\n').filter((line) => {
       return line.trim() !== '';
     });
 
     const lineObjArr = await Promise.all(
       noEmptyLinesArr.map(async (line) => {
         const lineArray = line.split('|');
-        const tagId = this.refNameToTagName(lineArray[5] || '');
+        const tagId = this.refNameToTagName(lineArray[8]?.trim() || '');
         const tag = tagId ? await this.tags.read({ path, id: tagId }) : null;
+        const collectionId = lineArray[4]?.trim();
 
         return {
           hash: lineArray[0],
-          // We don't want to parse the message because it could throw.
-          // Filtering it through isGitCommit ensures it's valid as a whole.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: JSON.parse(lineArray[1] || ''),
-          author: {
-            name: lineArray[2],
-            email: lineArray[3],
+          message: {
+            method: lineArray[1]?.trim(),
+            reference: {
+              objectType: lineArray[2]?.trim(),
+              id: lineArray[3]?.trim(),
+              ...(collectionId ? { collectionId } : {}),
+            },
           },
-          datetime: datetime(lineArray[4]),
+          author: {
+            name: lineArray[5],
+            email: lineArray[6],
+          },
+          datetime: datetime(lineArray[7]),
           tag,
         };
       })
     );
 
-    return lineObjArr.filter(this.isGitCommit.bind(this));
+    return lineObjArr.filter((obj) => this.isGitCommit(obj));
   }
 
   /**
@@ -593,12 +624,7 @@ export class GitService {
   ): Promise<string[]> {
     const relativeTreePath = treePath.replace(`${path}${Path.sep}`, '');
     const normalizedPath = relativeTreePath.split('\\').join('/');
-    const args = [
-      'ls-tree',
-      '--name-only',
-      commitRef,
-      `${normalizedPath}/`,
-    ];
+    const args = ['ls-tree', '--name-only', commitRef, `${normalizedPath}/`];
 
     try {
       const result = await this.git(path, args);

--- a/src/service/GitTagService.test.ts
+++ b/src/service/GitTagService.test.ts
@@ -24,10 +24,10 @@ describe('GitTagService', function () {
   it('should be able to create a new tag', async function () {
     tag = await core.git.tags.create({
       path: projectPath,
-      message: 'Initial tag',
+      message: { type: 'release', version: '1.0.0' },
     });
 
-    expect(tag.message).toEqual('Initial tag');
+    expect(tag.message).toEqual({ type: 'release', version: '1.0.0' });
   });
 
   it('should be able to read a tag', async function () {
@@ -36,7 +36,7 @@ describe('GitTagService', function () {
       id: tag.id,
     });
 
-    expect(readTag.message).toEqual('Initial tag');
+    expect(readTag.message).toEqual({ type: 'release', version: '1.0.0' });
   });
 
   it('should throw when trying to update a tag', function () {
@@ -59,6 +59,17 @@ describe('GitTagService', function () {
     expect(tags.list.length).toEqual(1);
   });
 
+  it('should preserve the full author email when listing tags', async function () {
+    const tags = await core.git.tags.list({
+      path: projectPath,
+    });
+
+    const listedTag = tags.list[0];
+    expect(listedTag).toBeDefined();
+    // The email should not have its last character truncated (double-slice bug)
+    expect(listedTag!.author.email).toEqual('john.doe@test.com');
+  });
+
   it('should be able to delete the tag', async function () {
     await core.git.tags.delete({
       path: projectPath,
@@ -73,10 +84,10 @@ describe('GitTagService', function () {
   it('should be able to create a new tag at specific commit hash', async function () {
     tag = await core.git.tags.create({
       path: projectPath,
-      message: 'Tagged HEAD',
+      message: { type: 'upgrade', coreVersion: '0.16.0' },
       hash: 'HEAD',
     });
 
-    expect(tag.message).toEqual('Tagged HEAD');
+    expect(tag.message).toEqual({ type: 'upgrade', coreVersion: '0.16.0' });
   });
 });

--- a/src/service/GitTagService.ts
+++ b/src/service/GitTagService.ts
@@ -3,6 +3,7 @@ import {
   countGitTagsSchema,
   createGitTagSchema,
   deleteGitTagSchema,
+  gitTagMessageSchema,
   gitTagSchema,
   listGitTagsSchema,
   readGitTagSchema,
@@ -13,6 +14,7 @@ import {
   type DeleteGitTagProps,
   type ElekIoCoreOptions,
   type GitTag,
+  type GitTagMessage,
   type ListGitTagsProps,
   type PaginatedList,
   type ReadGitTagProps,
@@ -56,7 +58,11 @@ export class GitTagService
       args = [...args, props.hash];
     }
 
-    args = [...args, '-m', props.message];
+    const subject = this.serializeTagMessage(props.message);
+    const trailers = this.tagMessageToTrailers(props.message);
+    const fullMessage = `${subject}\n\n${trailers.join('\n')}`;
+
+    args = [...args, '-m', fullMessage];
 
     await this.git(props.path, args);
     const tag = await this.read({ path: props.path, id });
@@ -127,14 +133,23 @@ export class GitTagService
 
     let args = ['tag', '--list'];
 
-    args = [
-      ...args,
-      '--sort=-*authordate',
-      '--format=%(refname:short)|%(subject)|%(*authorname)|%(*authoremail)|%(*authordate:iso-strict)',
-    ];
+    const format = [
+      '%(refname:short)',
+      '%(trailers:key=Type,valueonly)',
+      '%(trailers:key=Version,valueonly)',
+      '%(trailers:key=Core-Version,valueonly)',
+      '%(*authorname)',
+      '%(*authoremail)',
+      '%(*authordate:iso-strict)',
+    ].join('|');
+    args = [...args, '--sort=-*authordate', `--format=${format}`];
     const result = await this.git(props.path, args);
 
-    const noEmptyLinesArr = result.stdout.split('\n').filter((line) => {
+    // Trailer values from %(trailers:key=...,valueonly) include trailing newlines.
+    // Collapsing "\n|" into "|" rejoins the pipe-delimited fields into single lines.
+    const cleaned = result.stdout.replace(/\n\|/g, '|');
+
+    const noEmptyLinesArr = cleaned.split('\n').filter((line) => {
       return line.trim() !== '';
     });
 
@@ -143,19 +158,22 @@ export class GitTagService
 
       // Remove the '<' and '>' enclosing the email
       // @todo is there another format like authoremail that returns the original email?
-      if (lineArray[3]?.startsWith('<') && lineArray[3]?.endsWith('>')) {
-        lineArray[3] = lineArray[3].slice(1, -1);
-        lineArray[3] = lineArray[3].slice(0, -1);
+      if (lineArray[5]?.startsWith('<') && lineArray[5]?.endsWith('>')) {
+        lineArray[5] = lineArray[5].slice(1, -1);
       }
 
       return {
         id: lineArray[0],
-        message: lineArray[1],
+        message: this.parseTagTrailers(
+          lineArray[1]?.trim(),
+          lineArray[2]?.trim(),
+          lineArray[3]?.trim()
+        ),
         author: {
-          name: lineArray[2],
-          email: lineArray[3],
+          name: lineArray[4],
+          email: lineArray[5],
         },
-        datetime: datetime(lineArray[4]),
+        datetime: datetime(lineArray[6]),
       };
     });
 
@@ -182,6 +200,52 @@ export class GitTagService
 
     const gitTags = await this.list({ path: props.path });
     return gitTags.total;
+  }
+
+  /**
+   * Serializes a GitTagMessage into a human-readable subject line
+   */
+  private serializeTagMessage(message: GitTagMessage): string {
+    const type = message.type.charAt(0).toUpperCase() + message.type.slice(1);
+    const version =
+      message.type === 'upgrade' ? message.coreVersion : message.version;
+    return `${type} ${version}`;
+  }
+
+  /**
+   * Converts a GitTagMessage into git trailer lines
+   */
+  private tagMessageToTrailers(message: GitTagMessage): string[] {
+    const trailers = [`Type: ${message.type}`];
+    if (message.type === 'upgrade') {
+      trailers.push(`Core-Version: ${message.coreVersion}`);
+    } else {
+      trailers.push(`Version: ${message.version}`);
+    }
+    return trailers;
+  }
+
+  /**
+   * Parses git trailer values back into a GitTagMessage
+   */
+  private parseTagTrailers(
+    type: string | undefined,
+    version: string | undefined,
+    coreVersion: string | undefined
+  ): GitTagMessage | null {
+    switch (type) {
+      case 'upgrade':
+        return gitTagMessageSchema.parse({ type, coreVersion });
+      case 'release':
+      case 'preview':
+        return gitTagMessageSchema.parse({ type, version });
+      default:
+        this.logService.warn({
+          source: 'core',
+          message: `Tag with ID "${type}" has an invalid or missing Type trailer and will be ignored`,
+        });
+        return null;
+    }
   }
 
   /**

--- a/src/service/ProjectService.test.ts
+++ b/src/service/ProjectService.test.ts
@@ -43,7 +43,9 @@ describe('ProjectService', function () {
     expect(await Fs.pathExists(core.util.pathTo.project(project.id))).toBe(
       true
     );
-    const { history, fullHistory } = await core.projects.history({ id: project.id });
+    const { history, fullHistory } = await core.projects.history({
+      id: project.id,
+    });
     expect(history.length).toEqual(1);
     expect(fullHistory.length).toEqual(1);
     await ensureCleanGitStatus(task, project.id);
@@ -65,7 +67,9 @@ describe('ProjectService', function () {
       // @ts-expect-error updated is not allowed to be null
       Math.floor(new Date(updatedProject.updated).getTime() / 1000)
     ).to.approximately(Math.floor(Date.now() / 1000), 5); // 5 seconds of delta allowed
-    const { history, fullHistory } = await core.projects.history({ id: project.id });
+    const { history, fullHistory } = await core.projects.history({
+      id: project.id,
+    });
     expect(history.length).toEqual(2);
     expect(fullHistory.length).toEqual(2);
     await ensureCleanGitStatus(task, project.id);
@@ -77,7 +81,9 @@ describe('ProjectService', function () {
     const asset = await createAsset(project.id);
     const collection = await createCollection(project.id);
     await createEntry(project.id, collection.id, asset.id);
-    const { history, fullHistory } = await core.projects.history({ id: project.id });
+    const { history, fullHistory } = await core.projects.history({
+      id: project.id,
+    });
 
     expect(history.length).toEqual(2);
     expect(fullHistory.length).toEqual(6); // Now with new Asset, Collection and Entry

--- a/src/service/ProjectService.test.ts
+++ b/src/service/ProjectService.test.ts
@@ -43,8 +43,9 @@ describe('ProjectService', function () {
     expect(await Fs.pathExists(core.util.pathTo.project(project.id))).toBe(
       true
     );
-    expect(project.history.length).toEqual(1);
-    expect(project.fullHistory.length).toEqual(1);
+    const { history, fullHistory } = await core.projects.history({ id: project.id });
+    expect(history.length).toEqual(1);
+    expect(fullHistory.length).toEqual(1);
     await ensureCleanGitStatus(task, project.id);
   });
 
@@ -64,8 +65,9 @@ describe('ProjectService', function () {
       // @ts-expect-error updated is not allowed to be null
       Math.floor(new Date(updatedProject.updated).getTime() / 1000)
     ).to.approximately(Math.floor(Date.now() / 1000), 5); // 5 seconds of delta allowed
-    expect(updatedProject.history.length).toEqual(2);
-    expect(updatedProject.fullHistory.length).toEqual(2);
+    const { history, fullHistory } = await core.projects.history({ id: project.id });
+    expect(history.length).toEqual(2);
+    expect(fullHistory.length).toEqual(2);
     await ensureCleanGitStatus(task, project.id);
   });
 
@@ -75,21 +77,21 @@ describe('ProjectService', function () {
     const asset = await createAsset(project.id);
     const collection = await createCollection(project.id);
     await createEntry(project.id, collection.id, asset.id);
-    const readProject = await core.projects.read({ id: project.id });
+    const { history, fullHistory } = await core.projects.history({ id: project.id });
 
-    expect(readProject.history.length).toEqual(2);
-    expect(readProject.fullHistory.length).toEqual(6); // Now with new Asset, Collection and Entry
+    expect(history.length).toEqual(2);
+    expect(fullHistory.length).toEqual(6); // Now with new Asset, Collection and Entry
     await ensureCleanGitStatus(task, project.id);
   });
 
   it('should be able to get the content of a Project at a specific commit', async function () {
-    const readProject = await core.projects.read({ id: project.id });
+    const { history } = await core.projects.history({ id: project.id });
 
-    expect(readProject.history.length).toEqual(2);
+    expect(history.length).toEqual(2);
 
     const projectFromHistory = await core.projects.read({
       id: project.id,
-      commitHash: readProject.history.pop()?.hash,
+      commitHash: history.at(-1)?.hash,
     });
 
     expect(projectFromHistory.name).toEqual('project #1');

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -224,7 +224,9 @@ export class ProjectService
   /**
    * Returns the commit history of a Project
    */
-  public async history(props: ProjectHistoryProps): Promise<ProjectHistoryResult> {
+  public async history(
+    props: ProjectHistoryProps
+  ): Promise<ProjectHistoryResult> {
     projectHistorySchema.parse(props);
     const projectPath = pathTo.project(props.id);
 

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -115,7 +115,6 @@ export class ProjectService
       created: datetime(),
       updated: null,
       coreVersion: this.coreVersion,
-      status: 'todo',
       version: '0.0.1',
     };
 
@@ -598,8 +597,6 @@ export class ProjectService
    * Migrates an potentially outdated Project file to the current schema
    */
   public migrate(props: MigrateProjectProps) {
-    // @todo
-
     props.coreVersion = this.coreVersion;
 
     return projectFileSchema.parse(props);

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -374,7 +374,10 @@ export class ProjectService
       });
       await this.gitService.tags.create({
         path: projectPath,
-        message: `Upgraded Project to Core version ${migratedProjectFile.coreVersion}`,
+        message: {
+          type: 'upgrade',
+          coreVersion: migratedProjectFile.coreVersion,
+        },
       });
       await this.gitService.branches.delete(
         projectPath,

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -27,6 +27,7 @@ import {
   projectBranchSchema,
   projectFileSchema,
   projectFolderSchema,
+  projectHistorySchema,
   readProjectSchema,
   serviceTypeSchema,
   setRemoteOriginUrlProjectSchema,
@@ -46,6 +47,8 @@ import {
   type PaginatedList,
   type Project,
   type ProjectFile,
+  type ProjectHistoryProps,
+  type ProjectHistoryResult,
   type ReadProjectProps,
   type SetRemoteOriginUrlProjectProps,
   type SwitchBranchProjectProps,
@@ -216,6 +219,21 @@ export class ProjectService
 
       return await this.toProject(projectFile);
     }
+  }
+
+  /**
+   * Returns the commit history of a Project
+   */
+  public async history(props: ProjectHistoryProps): Promise<ProjectHistoryResult> {
+    projectHistorySchema.parse(props);
+    const projectPath = pathTo.project(props.id);
+
+    const fullHistory = await this.gitService.log(projectPath);
+    const history = await this.gitService.log(projectPath, {
+      filePath: pathTo.projectFile(props.id),
+    });
+
+    return { history, fullHistory };
   }
 
   /**
@@ -594,18 +612,9 @@ export class ProjectService
       remoteOriginUrl = await this.gitService.remotes.getOriginUrl(projectPath);
     }
 
-    const fullHistory = await this.gitService.log(
-      pathTo.project(projectFile.id)
-    );
-    const history = await this.gitService.log(pathTo.project(projectFile.id), {
-      filePath: pathTo.projectFile(projectFile.id),
-    });
-
     return {
       ...projectFile,
       remoteOriginUrl,
-      history,
-      fullHistory,
     };
   }
 

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -641,6 +641,7 @@ export class ProjectService
       '!/**/.gitkeep',
       '',
       '# elek.io related ignores',
+      'collections/index.json',
       // projectFolderSchema.enum.theme + '/',
       // projectFolderSchema.enum.public + '/',
       // projectFolderSchema.enum.logs + '/',

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -11,7 +11,6 @@ import { SynchronizeLocalChangesError } from '../error/SynchronizeLocalChangesEr
 import type {
   FileReference,
   ObjectType,
-  MigrateProjectProps,
   Version,
 } from '../schema/index.js';
 import {
@@ -56,6 +55,7 @@ import {
   type UpdateProjectProps,
   type UpgradeProjectProps,
 } from '../schema/index.js';
+import { applyMigrations, projectMigrations } from './migrations/index.js';
 import { isNotEmpty, pathTo } from '../util/node.js';
 import { datetime, uuid } from '../util/shared.js';
 import { AbstractCrudService } from './AbstractCrudService.js';
@@ -205,13 +205,11 @@ export class ProjectService
       return await this.toProject(projectFile);
     } else {
       const projectFile = this.migrate(
-        migrateProjectSchema.parse(
-          JSON.parse(
-            await this.gitService.getFileContentAtCommit(
-              pathTo.project(props.id),
-              pathTo.projectFile(props.id),
-              props.commitHash
-            )
+        JSON.parse(
+          await this.gitService.getFileContentAtCommit(
+            pathTo.project(props.id),
+            pathTo.projectFile(props.id),
+            props.commitHash
           )
         )
       );
@@ -282,10 +280,8 @@ export class ProjectService
       );
     }
 
-    // Get the current Project file
-    const currentProjectFile = migrateProjectSchema.parse(
-      await this.jsonFileService.unsafeRead(projectFilePath)
-    );
+    // Get the current Project file (loose-parsed for version checks; full migration happens in upgradeObjectFile)
+    const currentProjectFile = await this.jsonFileService.unsafeRead(projectFilePath) as Record<string, unknown> & { coreVersion: string };
 
     if (Semver.gt(currentProjectFile.coreVersion, this.coreVersion)) {
       // Upgrade of the client needed before the project can be upgraded
@@ -526,7 +522,7 @@ export class ProjectService
   /**
    * Lists outdated Projects that need to be upgraded
    */
-  public async listOutdated(): Promise<MigrateProjectProps[]> {
+  public async listOutdated(): Promise<ProjectFile[]> {
     const projectReferences = await this.listReferences(
       objectTypeSchema.enum.project
     );
@@ -539,7 +535,7 @@ export class ProjectService
         const projectFile = migrateProjectSchema.parse(json);
 
         if (projectFile.coreVersion !== this.coreVersion) {
-          return projectFile;
+          return this.migrate(projectFile);
         }
 
         return null;
@@ -596,10 +592,10 @@ export class ProjectService
   /**
    * Migrates an potentially outdated Project file to the current schema
    */
-  public migrate(props: MigrateProjectProps) {
-    props.coreVersion = this.coreVersion;
-
-    return projectFileSchema.parse(props);
+  public migrate(potentiallyOutdatedFile: unknown): ProjectFile {
+    const loose = migrateProjectSchema.parse(potentiallyOutdatedFile);
+    const migrated = applyMigrations(loose, projectMigrations, this.coreVersion);
+    return projectFileSchema.parse(migrated);
   }
 
   /**

--- a/src/service/ProjectService.ts
+++ b/src/service/ProjectService.ts
@@ -8,11 +8,7 @@ import {
 } from '../error/index.js';
 import { RemoteOriginMissingError } from '../error/RemoteOriginMissingError.js';
 import { SynchronizeLocalChangesError } from '../error/SynchronizeLocalChangesError.js';
-import type {
-  FileReference,
-  ObjectType,
-  Version,
-} from '../schema/index.js';
+import type { FileReference, ObjectType, Version } from '../schema/index.js';
 import {
   cloneProjectSchema,
   createProjectSchema,
@@ -281,7 +277,9 @@ export class ProjectService
     }
 
     // Get the current Project file (loose-parsed for version checks; full migration happens in upgradeObjectFile)
-    const currentProjectFile = await this.jsonFileService.unsafeRead(projectFilePath) as Record<string, unknown> & { coreVersion: string };
+    const currentProjectFile = (await this.jsonFileService.unsafeRead(
+      projectFilePath
+    )) as Record<string, unknown> & { coreVersion: string };
 
     if (Semver.gt(currentProjectFile.coreVersion, this.coreVersion)) {
       // Upgrade of the client needed before the project can be upgraded
@@ -594,7 +592,11 @@ export class ProjectService
    */
   public migrate(potentiallyOutdatedFile: unknown): ProjectFile {
     const loose = migrateProjectSchema.parse(potentiallyOutdatedFile);
-    const migrated = applyMigrations(loose, projectMigrations, this.coreVersion);
+    const migrated = applyMigrations(
+      loose,
+      projectMigrations,
+      this.coreVersion
+    );
     return projectFileSchema.parse(migrated);
   }
 

--- a/src/service/ReleaseService.test.ts
+++ b/src/service/ReleaseService.test.ts
@@ -1,7 +1,14 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import core, { type Collection, type Project } from '../test/setup.js';
+import core, {
+  type Asset,
+  type Collection,
+  type Entry,
+  type Project,
+} from '../test/setup.js';
 import {
+  createAsset,
   createCollection,
+  createEntry,
   createProject,
   ensureCleanGitStatus,
 } from '../test/util.js';
@@ -9,6 +16,8 @@ import {
 describe('ReleaseService', function () {
   let project: Project & { destroy: () => Promise<void> };
   let collection: Collection;
+  let asset: Asset;
+  let entry: Entry;
 
   beforeAll(async function () {
     project = await createProject();
@@ -141,9 +150,9 @@ describe('ReleaseService', function () {
     const diff = await core.releases.prepare({ projectId: project.id });
 
     expect(diff.bump).toEqual('patch');
-    expect(
-      diff.fieldChanges.some((c) => c.changeType === 'labelChanged')
-    ).toBe(true);
+    expect(diff.fieldChanges.some((c) => c.changeType === 'labelChanged')).toBe(
+      true
+    );
   });
 
   it('should create another patch release for field label change', async function () {
@@ -168,9 +177,7 @@ describe('ReleaseService', function () {
 
     expect(diff.bump).toEqual('minor');
     expect(
-      diff.fieldChanges.some(
-        (c) => c.changeType === 'isNotRequiredToRequired'
-      )
+      diff.fieldChanges.some((c) => c.changeType === 'isNotRequiredToRequired')
     ).toBe(true);
   });
 
@@ -194,9 +201,9 @@ describe('ReleaseService', function () {
     const diff = await core.releases.prepare({ projectId: project.id });
 
     expect(diff.bump).toEqual('major');
-    expect(
-      diff.fieldChanges.some((c) => c.changeType === 'deleted')
-    ).toBe(true);
+    expect(diff.fieldChanges.some((c) => c.changeType === 'deleted')).toBe(
+      true
+    );
   });
 
   it('should create a major release', async function () {
@@ -236,14 +243,276 @@ describe('ReleaseService', function () {
     const diff = await core.releases.prepare({ projectId: project.id });
 
     expect(diff.bump).toEqual('major');
-    expect(
-      diff.collectionChanges.some((c) => c.changeType === 'deleted')
-    ).toBe(true);
+    expect(diff.collectionChanges.some((c) => c.changeType === 'deleted')).toBe(
+      true
+    );
   });
 
   it('should create a major release for deleted collection', async function () {
     const result = await core.releases.create({ projectId: project.id });
 
     expect(result.version).toEqual('2.0.0');
+  });
+
+  it('should detect MINOR bump when an asset is added', async function () {
+    // Create a new collection and asset for subsequent tests
+    collection = await createCollection(project.id);
+    asset = await createAsset(project.id);
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('minor');
+    expect(
+      diff.assetChanges.some(
+        (c) => c.changeType === 'added' && c.assetId === asset.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a minor release for added asset and collection', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('2.1.0');
+  });
+
+  it('should detect PATCH bump when asset metadata changes', async function () {
+    await core.assets.update({
+      projectId: project.id,
+      id: asset.id,
+      name: 'Updated Asset Name',
+      description: 'Updated description',
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('patch');
+    expect(
+      diff.assetChanges.some(
+        (c) => c.changeType === 'metadataChanged' && c.assetId === asset.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a patch release for asset metadata change', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('2.1.1');
+  });
+
+  it('should detect MAJOR bump when an asset is deleted', async function () {
+    await core.assets.delete({
+      projectId: project.id,
+      id: asset.id,
+      extension: asset.extension,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('major');
+    expect(
+      diff.assetChanges.some(
+        (c) => c.changeType === 'deleted' && c.assetId === asset.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a major release for deleted asset', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('3.0.0');
+  });
+
+  it('should detect MINOR bump when an entry is added', async function () {
+    // Need an asset for the entry's asset reference field
+    asset = await createAsset(project.id);
+    entry = await createEntry(project.id, collection.id, asset.id);
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('minor');
+    expect(
+      diff.entryChanges.some(
+        (c) => c.changeType === 'added' && c.entryId === entry.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a minor release for added entry', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('3.1.0');
+  });
+
+  it('should detect PATCH bump when entry values change', async function () {
+    await core.entries.update({
+      projectId: project.id,
+      collectionId: collection.id,
+      id: entry.id,
+      values: {
+        ...entry.values,
+        'product-name': {
+          objectType: 'value',
+          valueType: 'string',
+          content: {
+            en: 'Modified Product Name',
+          },
+        },
+      },
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('patch');
+    expect(
+      diff.entryChanges.some(
+        (c) => c.changeType === 'modified' && c.entryId === entry.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a patch release for modified entry', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('3.1.1');
+  });
+
+  it('should detect MAJOR bump when an entry is deleted', async function () {
+    await core.entries.delete({
+      projectId: project.id,
+      collectionId: collection.id,
+      id: entry.id,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('major');
+    expect(
+      diff.entryChanges.some(
+        (c) => c.changeType === 'deleted' && c.entryId === entry.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a major release for deleted entry', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('4.0.0');
+  });
+
+  it('should detect PATCH bump when project name changes', async function () {
+    await core.projects.update({
+      id: project.id,
+      name: 'Renamed Project',
+      description: project.description,
+      settings: project.settings,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('patch');
+    expect(
+      diff.projectChanges.some((c) => c.changeType === 'nameChanged')
+    ).toBe(true);
+  });
+
+  it('should create a patch release for project name change', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('4.0.1');
+    // Update local reference
+    // Project state is re-read in subsequent tests to avoid stale references
+  });
+
+  it('should detect MINOR bump when a supported language is added', async function () {
+    const currentProject = await core.projects.read({ id: project.id });
+
+    await core.projects.update({
+      id: project.id,
+      name: currentProject.name,
+      description: currentProject.description,
+      settings: {
+        language: {
+          default: currentProject.settings.language.default,
+          supported: [...currentProject.settings.language.supported, 'fr'],
+        },
+      },
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('minor');
+    expect(
+      diff.projectChanges.some((c) => c.changeType === 'supportedLanguageAdded')
+    ).toBe(true);
+  });
+
+  it('should create a minor release for added language', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('4.1.0');
+    // Project state is re-read in subsequent tests to avoid stale references
+  });
+
+  it('should detect MAJOR bump when the default language changes', async function () {
+    const currentProject = await core.projects.read({ id: project.id });
+
+    await core.projects.update({
+      id: project.id,
+      name: currentProject.name,
+      description: currentProject.description,
+      settings: {
+        language: {
+          default: 'de',
+          supported: currentProject.settings.language.supported,
+        },
+      },
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('major');
+    expect(
+      diff.projectChanges.some((c) => c.changeType === 'defaultLanguageChanged')
+    ).toBe(true);
+  });
+
+  it('should create a major release for default language change', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('5.0.0');
+    // Project state is re-read in subsequent tests to avoid stale references
+  });
+
+  it('should detect MAJOR bump when a supported language is removed', async function () {
+    const currentProject = await core.projects.read({ id: project.id });
+
+    await core.projects.update({
+      id: project.id,
+      name: currentProject.name,
+      description: currentProject.description,
+      settings: {
+        language: {
+          default: currentProject.settings.language.default,
+          supported: currentProject.settings.language.supported.filter(
+            (l) => l !== 'en'
+          ),
+        },
+      },
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('major');
+    expect(
+      diff.projectChanges.some(
+        (c) => c.changeType === 'supportedLanguageRemoved'
+      )
+    ).toBe(true);
+  });
+
+  it('should create a major release for removed language', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('6.0.0');
   });
 });

--- a/src/service/ReleaseService.test.ts
+++ b/src/service/ReleaseService.test.ts
@@ -1,0 +1,249 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import core, { type Collection, type Project } from '../test/setup.js';
+import {
+  createCollection,
+  createProject,
+  ensureCleanGitStatus,
+} from '../test/util.js';
+
+describe('ReleaseService', function () {
+  let project: Project & { destroy: () => Promise<void> };
+  let collection: Collection;
+
+  beforeAll(async function () {
+    project = await createProject();
+  });
+
+  afterAll(async function () {
+    await project.destroy();
+  });
+
+  afterEach(async function ({ task }) {
+    await ensureCleanGitStatus(task, project.id);
+  });
+
+  it('should detect new collections as MINOR bump on first release', async function () {
+    collection = await createCollection(project.id);
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('minor');
+    expect(diff.currentVersion).toEqual('0.0.1');
+    expect(diff.nextVersion).toEqual('0.1.0');
+    expect(diff.collectionChanges.length).toBeGreaterThanOrEqual(1);
+    expect(
+      diff.collectionChanges.some(
+        (c) => c.changeType === 'added' && c.collectionId === collection.id
+      )
+    ).toBe(true);
+  });
+
+  it('should create a preview release before full release', async function () {
+    const result = await core.releases.createPreview({
+      projectId: project.id,
+    });
+
+    expect(result.version).toEqual('0.1.0-preview.1');
+    expect(result.diff.bump).toEqual('minor');
+
+    // Verify project version was updated to preview
+    const updatedProject = await core.projects.read({ id: project.id });
+    expect(updatedProject.version).toEqual('0.1.0-preview.1');
+
+    // Verify we're still on work branch (no merge to production)
+    const currentBranch = await core.git.branches.current(
+      core.util.pathTo.project(project.id)
+    );
+    expect(currentBranch).toEqual('work');
+  });
+
+  it('should increment preview number on subsequent preview releases', async function () {
+    // Make a small change so there's something new
+    collection.name.singular.en = 'Preview Product';
+    await core.collections.update({
+      projectId: project.id,
+      ...collection,
+    });
+
+    const result = await core.releases.createPreview({
+      projectId: project.id,
+    });
+
+    expect(result.version).toEqual('0.1.0-preview.2');
+  });
+
+  it('should create a first full release successfully', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('0.1.0');
+    expect(result.diff.bump).toEqual('minor');
+
+    // Verify project version was updated
+    const updatedProject = await core.projects.read({ id: project.id });
+    expect(updatedProject.version).toEqual('0.1.0');
+
+    // Verify we're back on work branch
+    const currentBranch = await core.git.branches.current(
+      core.util.pathTo.project(project.id)
+    );
+    expect(currentBranch).toEqual('work');
+  });
+
+  it('should detect no changes after a release', async function () {
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toBeNull();
+    expect(diff.nextVersion).toBeNull();
+  });
+
+  it('should throw when creating a release with no changes', async function () {
+    await expect(
+      core.releases.create({ projectId: project.id })
+    ).rejects.toThrow('no changes detected since the last full release');
+  });
+
+  it('should throw when creating a preview release with no changes', async function () {
+    await expect(
+      core.releases.createPreview({ projectId: project.id })
+    ).rejects.toThrow('no changes detected since the last full release');
+  });
+
+  it('should detect PATCH bump for label changes', async function () {
+    collection.name.singular.en = 'Updated Product';
+    await core.collections.update({
+      projectId: project.id,
+      ...collection,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    // Collection field definitions didn't change, but the collection was updated
+    // This shows as content-only changes (PATCH) since it's a commit between branches
+    expect(diff.bump).toEqual('patch');
+  });
+
+  it('should create a patch release', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('0.1.1');
+    expect(result.diff.bump).toEqual('patch');
+  });
+
+  it('should detect PATCH bump for field label changes', async function () {
+    const field = collection.fieldDefinitions[0]!;
+    field.label.en = 'Updated Label';
+
+    await core.collections.update({
+      projectId: project.id,
+      ...collection,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('patch');
+    expect(
+      diff.fieldChanges.some((c) => c.changeType === 'labelChanged')
+    ).toBe(true);
+  });
+
+  it('should create another patch release for field label change', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('0.1.2');
+  });
+
+  it('should detect MINOR bump when a field becomes required', async function () {
+    // The entry reference field is currently not required
+    const entryRefField = collection.fieldDefinitions.find(
+      (fd) => fd.fieldType === 'entry'
+    )!;
+    (entryRefField as { isRequired: boolean }).isRequired = true;
+
+    await core.collections.update({
+      projectId: project.id,
+      ...collection,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('minor');
+    expect(
+      diff.fieldChanges.some(
+        (c) => c.changeType === 'isNotRequiredToRequired'
+      )
+    ).toBe(true);
+  });
+
+  it('should create a minor release', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('0.2.0');
+  });
+
+  it('should detect MAJOR bump when a field is deleted', async function () {
+    // Remove the entry reference field
+    collection.fieldDefinitions = collection.fieldDefinitions.filter(
+      (fd) => fd.fieldType !== 'entry'
+    );
+
+    await core.collections.update({
+      projectId: project.id,
+      ...collection,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('major');
+    expect(
+      diff.fieldChanges.some((c) => c.changeType === 'deleted')
+    ).toBe(true);
+  });
+
+  it('should create a major release', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('1.0.0');
+  });
+
+  it('should reset preview numbering after a full release', async function () {
+    // Make a change after the full release
+    collection.description.en = 'Changed description after v1';
+    await core.collections.update({
+      projectId: project.id,
+      ...collection,
+    });
+
+    const result = await core.releases.createPreview({
+      projectId: project.id,
+    });
+
+    // New base version (1.0.1 patch), preview count resets to 1
+    expect(result.version).toEqual('1.0.1-preview.1');
+  });
+
+  it('should still be able to do a full release after preview', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('1.0.1');
+  });
+
+  it('should detect MAJOR bump when a collection is deleted', async function () {
+    await core.collections.delete({
+      projectId: project.id,
+      id: collection.id,
+    });
+
+    const diff = await core.releases.prepare({ projectId: project.id });
+
+    expect(diff.bump).toEqual('major');
+    expect(
+      diff.collectionChanges.some((c) => c.changeType === 'deleted')
+    ).toBe(true);
+  });
+
+  it('should create a major release for deleted collection', async function () {
+    const result = await core.releases.create({ projectId: project.id });
+
+    expect(result.version).toEqual('2.0.0');
+  });
+});

--- a/src/service/ReleaseService.ts
+++ b/src/service/ReleaseService.ts
@@ -1,0 +1,775 @@
+import { isDeepStrictEqual } from 'node:util';
+import Semver from 'semver';
+import {
+  collectionFileSchema,
+  projectBranchSchema,
+  projectFileSchema,
+  serviceTypeSchema,
+  prepareReleaseSchema,
+  createReleaseSchema,
+  createPreviewReleaseSchema,
+  releaseTagMessageSchema,
+  type CollectionFile,
+  type ElekIoCoreOptions,
+  type FieldDefinition,
+  type PrepareReleaseProps,
+  type CreateReleaseProps,
+  type CreatePreviewReleaseProps,
+  type ReleaseDiff,
+  type ReleaseResult,
+  type SemverBump,
+  type FieldChange,
+  type CollectionChange,
+} from '../schema/index.js';
+import { pathTo } from '../util/node.js';
+import { datetime } from '../util/shared.js';
+import { AbstractCrudService } from './AbstractCrudService.js';
+import type { CollectionService } from './CollectionService.js';
+import type { GitService } from './GitService.js';
+import type { JsonFileService } from './JsonFileService.js';
+import type { LogService } from './LogService.js';
+import type { ProjectService } from './ProjectService.js';
+
+/**
+ * Service that manages Release functionality
+ *
+ * A release diffs the current `work` branch against the `production` branch
+ * to determine what changed, computes a semver bump, and merges work into production.
+ */
+export class ReleaseService extends AbstractCrudService {
+  private gitService: GitService;
+  private jsonFileService: JsonFileService;
+  private collectionService: CollectionService;
+  private projectService: ProjectService;
+
+  constructor(
+    options: ElekIoCoreOptions,
+    logService: LogService,
+    gitService: GitService,
+    jsonFileService: JsonFileService,
+    collectionService: CollectionService,
+    projectService: ProjectService
+  ) {
+    super(serviceTypeSchema.enum.Release, options, logService);
+
+    this.gitService = gitService;
+    this.jsonFileService = jsonFileService;
+    this.collectionService = collectionService;
+    this.projectService = projectService;
+  }
+
+  /**
+   * Prepares a release by diffing the current `work` branch against `production`.
+   *
+   * Returns a read-only summary of all changes and the computed next version.
+   * If there are no changes, the next version and bump will be null.
+   */
+  public async prepare(props: PrepareReleaseProps): Promise<ReleaseDiff> {
+    prepareReleaseSchema.parse(props);
+
+    const projectPath = pathTo.project(props.projectId);
+
+    // Ensure we're on the work branch
+    const currentBranch = await this.gitService.branches.current(projectPath);
+    if (currentBranch !== projectBranchSchema.enum.work) {
+      throw new Error(`Not on work branch (currently on "${currentBranch}")`);
+    }
+
+    const project = await this.projectService.read({ id: props.projectId });
+    const currentVersion = project.version;
+
+    // Get current collections from work branch (disk)
+    const currentCollections = await this.collectionService.list({
+      projectId: props.projectId,
+      limit: 0,
+    });
+
+    // Get collections from production branch
+    const productionCollections = await this.getCollectionsAtRef(
+      props.projectId,
+      projectPath,
+      projectBranchSchema.enum.production
+    );
+
+    // Diff collections
+    const { bump, collectionChanges, fieldChanges } = this.diffCollections(
+      currentCollections.list,
+      productionCollections
+    );
+
+    // If no schema changes, check if there are any commits between production and work
+    let finalBump = bump;
+    if (!finalBump) {
+      const hasContentChanges = await this.hasCommitsBetween(
+        projectPath,
+        projectBranchSchema.enum.production,
+        projectBranchSchema.enum.work
+      );
+      if (hasContentChanges) {
+        finalBump = 'patch';
+      }
+    }
+
+    const nextVersion = finalBump
+      ? Semver.inc(currentVersion, finalBump)
+      : null;
+
+    return {
+      project,
+      bump: finalBump,
+      currentVersion,
+      nextVersion,
+      collectionChanges,
+      fieldChanges,
+    };
+  }
+
+  /**
+   * Creates a release by:
+   * 1. Recomputing the diff (stateless)
+   * 2. Merging `work` into `production`
+   * 3. Updating the project version on `production`
+   * 4. Tagging on `production`
+   * 5. Merging `production` back into `work` (fast-forward to sync the version commit)
+   * 6. Switching back to `work`
+   */
+  public async create(props: CreateReleaseProps): Promise<ReleaseResult> {
+    createReleaseSchema.parse(props);
+
+    const projectPath = pathTo.project(props.projectId);
+    const projectFilePath = pathTo.projectFile(props.projectId);
+
+    // Recompute the diff
+    const diff = await this.prepare(props);
+
+    if (!diff.bump || !diff.nextVersion) {
+      throw new Error(
+        'Cannot create a release: no changes detected since the last full release'
+      );
+    }
+
+    const nextVersion = diff.nextVersion;
+
+    try {
+      // Merge work into production
+      await this.gitService.branches.switch(
+        projectPath,
+        projectBranchSchema.enum.production
+      );
+      await this.gitService.merge(projectPath, projectBranchSchema.enum.work);
+
+      // Update project version on production
+      const updatedProjectFile = {
+        ...diff.project,
+        version: nextVersion,
+        updated: datetime(),
+      };
+
+      await this.jsonFileService.update(
+        updatedProjectFile,
+        projectFilePath,
+        projectFileSchema
+      );
+      await this.gitService.add(projectPath, [projectFilePath]);
+      await this.gitService.commit(projectPath, {
+        method: 'release',
+        reference: { objectType: 'project', id: props.projectId },
+      });
+
+      // Tag on production
+      await this.gitService.tags.create({
+        path: projectPath,
+        message: JSON.stringify(
+          releaseTagMessageSchema.parse({
+            type: 'release',
+            version: nextVersion,
+          })
+        ),
+      });
+
+      // Switch back to work and sync the version commit
+      await this.gitService.branches.switch(
+        projectPath,
+        projectBranchSchema.enum.work
+      );
+      await this.gitService.merge(
+        projectPath,
+        projectBranchSchema.enum.production
+      );
+    } catch (error) {
+      // Ensure we switch back to work branch on failure
+      await this.gitService.branches
+        .switch(projectPath, projectBranchSchema.enum.work)
+        .catch(() => {
+          // Best-effort recovery — log but don't mask the original error
+        });
+      throw error;
+    }
+
+    this.logService.info({
+      source: 'core',
+      message: `Released version ${nextVersion} (${diff.bump} bump)`,
+    });
+
+    return {
+      version: nextVersion,
+      diff,
+    };
+  }
+
+  /**
+   * Creates a preview release by:
+   * 1. Recomputing the diff (stateless)
+   * 2. Computing the preview version (e.g. 1.1.0-preview.3)
+   * 3. Updating the project version on `work`
+   * 4. Tagging on `work` (no merge into production)
+   *
+   * Preview releases are snapshots of the current work state.
+   * They don't promote to production — only full releases do.
+   */
+  public async createPreview(
+    props: CreatePreviewReleaseProps
+  ): Promise<ReleaseResult> {
+    createPreviewReleaseSchema.parse(props);
+
+    const projectPath = pathTo.project(props.projectId);
+    const projectFilePath = pathTo.projectFile(props.projectId);
+
+    // Recompute the diff
+    const diff = await this.prepare(props);
+
+    if (!diff.bump || !diff.nextVersion) {
+      throw new Error(
+        'Cannot create a preview release: no changes detected since the last full release'
+      );
+    }
+
+    // Count existing preview tags for this base version to determine the N in preview.N
+    const previewNumber = await this.countPreviewsSinceLastRelease(
+      projectPath,
+      diff.nextVersion
+    );
+    const previewVersion = `${diff.nextVersion}-preview.${previewNumber + 1}`;
+
+    try {
+      // Update project version on work branch
+      const updatedProjectFile = {
+        ...diff.project,
+        version: previewVersion,
+        updated: datetime(),
+      };
+
+      await this.jsonFileService.update(
+        updatedProjectFile,
+        projectFilePath,
+        projectFileSchema
+      );
+      await this.gitService.add(projectPath, [projectFilePath]);
+      await this.gitService.commit(projectPath, {
+        method: 'release',
+        reference: { objectType: 'project', id: props.projectId },
+      });
+
+      // Tag on work (not production)
+      await this.gitService.tags.create({
+        path: projectPath,
+        message: JSON.stringify(
+          releaseTagMessageSchema.parse({
+            type: 'preview',
+            version: previewVersion,
+          })
+        ),
+      });
+    } catch (error) {
+      // Ensure we stay on work branch on failure
+      await this.gitService.branches
+        .switch(projectPath, projectBranchSchema.enum.work)
+        .catch(() => {
+          // Best-effort recovery — log but don't mask the original error
+        });
+      throw error;
+    }
+
+    this.logService.info({
+      source: 'core',
+      message: `Preview released version ${previewVersion} (${diff.bump} bump)`,
+    });
+
+    return {
+      version: previewVersion,
+      diff,
+    };
+  }
+
+  /**
+   * Reads collections as they exist at a given git ref (branch or commit)
+   */
+  private async getCollectionsAtRef(
+    projectId: string,
+    projectPath: string,
+    ref: string
+  ): Promise<CollectionFile[]> {
+    const collectionsPath = pathTo.collections(projectId);
+
+    // List collection folders at the ref
+    const folderNames = await this.gitService.listTreeAtCommit(
+      projectPath,
+      collectionsPath,
+      ref
+    );
+
+    const collections: CollectionFile[] = [];
+
+    for (const folderName of folderNames) {
+      const collectionFilePath = pathTo.collectionFile(projectId, folderName);
+
+      try {
+        const content = await this.gitService.getFileContentAtCommit(
+          projectPath,
+          collectionFilePath,
+          ref
+        );
+        const collectionFile = collectionFileSchema.parse(JSON.parse(content));
+        collections.push(collectionFile);
+      } catch {
+        // Collection may not have a valid collection.json (e.g. .gitkeep only)
+        this.logService.debug({
+          source: 'core',
+          message: `Skipping folder "${folderName}" at ref "${ref}" during release diff`,
+        });
+      }
+    }
+
+    return collections;
+  }
+
+  /**
+   * Checks if there are any commits between two refs
+   */
+  private async hasCommitsBetween(
+    projectPath: string,
+    from: string,
+    to: string
+  ): Promise<boolean> {
+    try {
+      const commits = await this.gitService.log(projectPath, {
+        between: { from, to },
+      });
+      return commits.length > 0;
+    } catch {
+      // If production branch has no commits yet (first release scenario),
+      // treat as having changes
+      return true;
+    }
+  }
+
+  /**
+   * Diffs two sets of collections and returns all changes with the computed bump level.
+   *
+   * Always collects all changes so they can be displayed to the user.
+   */
+  private diffCollections(
+    currentCollections: CollectionFile[],
+    productionCollections: CollectionFile[]
+  ): {
+    bump: SemverBump | null;
+    collectionChanges: CollectionChange[];
+    fieldChanges: FieldChange[];
+  } {
+    const collectionChanges: CollectionChange[] = [];
+    const fieldChanges: FieldChange[] = [];
+    let highestBump: SemverBump | null = null;
+
+    const currentById = new Map(currentCollections.map((c) => [c.id, c]));
+    const productionById = new Map(productionCollections.map((c) => [c.id, c]));
+
+    // Deleted collections (in production but not in current)
+    for (const [id] of productionById) {
+      if (!currentById.has(id)) {
+        collectionChanges.push({
+          collectionId: id,
+          changeType: 'deleted',
+          bump: 'major',
+        });
+        highestBump = 'major';
+      }
+    }
+
+    // New collections (in current but not in production)
+    for (const [id] of currentById) {
+      if (!productionById.has(id)) {
+        collectionChanges.push({
+          collectionId: id,
+          changeType: 'added',
+          bump: 'minor',
+        });
+        highestBump = this.higherBump(highestBump, 'minor');
+      }
+    }
+
+    // Matched collections — diff their field definitions
+    for (const [id, currentCollection] of currentById) {
+      const productionCollection = productionById.get(id);
+      if (!productionCollection) continue;
+
+      const changes = this.diffFieldDefinitions(
+        id,
+        currentCollection.fieldDefinitions,
+        productionCollection.fieldDefinitions
+      );
+
+      fieldChanges.push(...changes);
+
+      for (const change of changes) {
+        highestBump = this.higherBump(highestBump, change.bump);
+      }
+    }
+
+    return { bump: highestBump, collectionChanges, fieldChanges };
+  }
+
+  /**
+   * Diffs field definitions of a single collection.
+   *
+   * Matches fields by UUID and classifies each change.
+   * Always collects all changes so they can be displayed to the user.
+   */
+  private diffFieldDefinitions(
+    collectionId: string,
+    currentFields: FieldDefinition[],
+    productionFields: FieldDefinition[]
+  ): FieldChange[] {
+    const changes: FieldChange[] = [];
+
+    const currentById = new Map(currentFields.map((f) => [f.id, f]));
+    const productionById = new Map(productionFields.map((f) => [f.id, f]));
+
+    // Deleted fields
+    for (const [id, field] of productionById) {
+      if (!currentById.has(id)) {
+        changes.push({
+          collectionId,
+          fieldId: id,
+          fieldSlug: field.slug,
+          changeType: 'deleted',
+          bump: 'major',
+        });
+      }
+    }
+
+    // New fields
+    for (const [id, field] of currentById) {
+      if (!productionById.has(id)) {
+        changes.push({
+          collectionId,
+          fieldId: id,
+          fieldSlug: field.slug,
+          changeType: 'added',
+          bump: 'minor',
+        });
+      }
+    }
+
+    // Matched fields — compare property by property
+    for (const [id, currentField] of currentById) {
+      const productionField = productionById.get(id);
+      if (!productionField) continue;
+
+      const fieldChanges = this.diffSingleField(
+        collectionId,
+        currentField,
+        productionField
+      );
+
+      changes.push(...fieldChanges);
+    }
+
+    return changes;
+  }
+
+  /**
+   * Compares two versions of the same field definition and returns all detected changes.
+   *
+   * Collects every change on the field so the full diff can be shown to the user.
+   */
+  private diffSingleField(
+    collectionId: string,
+    current: FieldDefinition,
+    production: FieldDefinition
+  ): FieldChange[] {
+    const changes: FieldChange[] = [];
+    const base = {
+      collectionId,
+      fieldId: current.id,
+      fieldSlug: current.slug,
+    };
+
+    // MAJOR changes
+
+    if (current.valueType !== production.valueType) {
+      changes.push({ ...base, changeType: 'valueTypeChanged', bump: 'major' });
+    }
+
+    if (current.fieldType !== production.fieldType) {
+      changes.push({ ...base, changeType: 'fieldTypeChanged', bump: 'major' });
+    }
+
+    if (current.slug !== production.slug) {
+      changes.push({ ...base, changeType: 'slugChanged', bump: 'major' });
+    }
+
+    if (this.isMinMaxTightened(current, production)) {
+      changes.push({
+        ...base,
+        changeType: 'minMaxTightened',
+        bump: 'major',
+      });
+    }
+
+    if (production.isRequired === true && current.isRequired === false) {
+      changes.push({
+        ...base,
+        changeType: 'isRequiredToNotRequired',
+        bump: 'major',
+      });
+    }
+
+    if (production.isUnique === true && current.isUnique === false) {
+      changes.push({
+        ...base,
+        changeType: 'isUniqueToNotUnique',
+        bump: 'major',
+      });
+    }
+
+    if (current.fieldType === 'entry' && production.fieldType === 'entry') {
+      if (
+        !isDeepStrictEqual(
+          [...current.ofCollections].sort(),
+          [...production.ofCollections].sort()
+        )
+      ) {
+        changes.push({
+          ...base,
+          changeType: 'ofCollectionsChanged',
+          bump: 'major',
+        });
+      }
+    }
+
+    // MINOR changes
+
+    if (production.isRequired === false && current.isRequired === true) {
+      changes.push({
+        ...base,
+        changeType: 'isNotRequiredToRequired',
+        bump: 'minor',
+      });
+    }
+
+    if (production.isUnique === false && current.isUnique === true) {
+      changes.push({
+        ...base,
+        changeType: 'isNotUniqueToUnique',
+        bump: 'minor',
+      });
+    }
+
+    // PATCH changes
+
+    if (this.isMinMaxLoosened(current, production)) {
+      changes.push({
+        ...base,
+        changeType: 'minMaxLoosened',
+        bump: 'patch',
+      });
+    }
+
+    if (!isDeepStrictEqual(current.label, production.label)) {
+      changes.push({ ...base, changeType: 'labelChanged', bump: 'patch' });
+    }
+
+    if (!isDeepStrictEqual(current.description, production.description)) {
+      changes.push({
+        ...base,
+        changeType: 'descriptionChanged',
+        bump: 'patch',
+      });
+    }
+
+    if (
+      'defaultValue' in current &&
+      'defaultValue' in production &&
+      !isDeepStrictEqual(current.defaultValue, production.defaultValue)
+    ) {
+      changes.push({
+        ...base,
+        changeType: 'defaultValueChanged',
+        bump: 'patch',
+      });
+    }
+
+    if (current.inputWidth !== production.inputWidth) {
+      changes.push({
+        ...base,
+        changeType: 'inputWidthChanged',
+        bump: 'patch',
+      });
+    }
+
+    if (current.isDisabled !== production.isDisabled) {
+      changes.push({
+        ...base,
+        changeType: 'isDisabledChanged',
+        bump: 'patch',
+      });
+    }
+
+    return changes;
+  }
+
+  /**
+   * Checks if min/max constraints have been tightened.
+   *
+   * Tightening means: new min > old min, or new max < old max.
+   * A null value means no constraint (unbounded).
+   */
+  private isMinMaxTightened(
+    current: FieldDefinition,
+    production: FieldDefinition
+  ): boolean {
+    const currentMin = this.getMinMax(current, 'min');
+    const productionMin = this.getMinMax(production, 'min');
+    const currentMax = this.getMinMax(current, 'max');
+    const productionMax = this.getMinMax(production, 'max');
+
+    // Tightened min: was null (unbounded) and now has value, or increased
+    if (currentMin !== null && productionMin === null) return true;
+    if (
+      currentMin !== null &&
+      productionMin !== null &&
+      currentMin > productionMin
+    )
+      return true;
+
+    // Tightened max: was null (unbounded) and now has value, or decreased
+    if (currentMax !== null && productionMax === null) return true;
+    if (
+      currentMax !== null &&
+      productionMax !== null &&
+      currentMax < productionMax
+    )
+      return true;
+
+    return false;
+  }
+
+  /**
+   * Checks if min/max constraints have been loosened.
+   *
+   * Loosening means: new min < old min, or new max > old max.
+   */
+  private isMinMaxLoosened(
+    current: FieldDefinition,
+    production: FieldDefinition
+  ): boolean {
+    const currentMin = this.getMinMax(current, 'min');
+    const productionMin = this.getMinMax(production, 'min');
+    const currentMax = this.getMinMax(current, 'max');
+    const productionMax = this.getMinMax(production, 'max');
+
+    // Loosened min: had value and now null (unbounded), or decreased
+    if (currentMin === null && productionMin !== null) return true;
+    if (
+      currentMin !== null &&
+      productionMin !== null &&
+      currentMin < productionMin
+    )
+      return true;
+
+    // Loosened max: had value and now null (unbounded), or increased
+    if (currentMax === null && productionMax !== null) return true;
+    if (
+      currentMax !== null &&
+      productionMax !== null &&
+      currentMax > productionMax
+    )
+      return true;
+
+    return false;
+  }
+
+  /**
+   * Safely extracts min or max from a field definition (not all types have it)
+   */
+  private getMinMax(
+    field: FieldDefinition,
+    prop: 'min' | 'max'
+  ): number | null {
+    switch (field.fieldType) {
+      case 'text':
+      case 'textarea':
+      case 'number':
+      case 'range':
+      case 'asset':
+      case 'entry':
+        return field[prop];
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Counts existing preview tags for a given base version since the last full release.
+   *
+   * Parses all tag messages looking for `{ type: 'preview', version: 'X.Y.Z-preview.N' }`
+   * where the base version matches.
+   */
+  private async countPreviewsSinceLastRelease(
+    projectPath: string,
+    baseVersion: string
+  ): Promise<number> {
+    const tags = await this.gitService.tags.list({ path: projectPath });
+    let count = 0;
+
+    for (const tag of tags.list) {
+      let rawMessage: unknown = null;
+      try {
+        rawMessage = JSON.parse(tag.message);
+      } catch {
+        // Not JSON, skip
+      }
+      const parsed = releaseTagMessageSchema.safeParse(rawMessage);
+
+      if (!parsed.success) continue;
+
+      if (parsed.data.type === 'release') {
+        // Hit the last full release — stop counting
+        break;
+      }
+
+      if (parsed.data.type === 'preview') {
+        // Check if this preview is for the same base version
+        const previewBase = parsed.data.version.split('-')[0];
+        if (previewBase === baseVersion) {
+          count++;
+        }
+      }
+    }
+
+    return count;
+  }
+
+  /**
+   * Returns the higher of two bumps (major > minor > patch)
+   */
+  private higherBump(a: SemverBump | null, b: SemverBump): SemverBump {
+    const order: Record<SemverBump, number> = {
+      patch: 0,
+      minor: 1,
+      major: 2,
+    };
+    if (a === null) return b;
+    return order[a] >= order[b] ? a : b;
+  }
+}

--- a/src/service/ReleaseService.ts
+++ b/src/service/ReleaseService.ts
@@ -10,7 +10,6 @@ import {
   prepareReleaseSchema,
   createReleaseSchema,
   createPreviewReleaseSchema,
-  releaseTagMessageSchema,
   type AssetChange,
   type AssetFile,
   type CollectionFile,
@@ -230,12 +229,7 @@ export class ReleaseService extends AbstractCrudService {
       // Tag on production
       await this.gitService.tags.create({
         path: projectPath,
-        message: JSON.stringify(
-          releaseTagMessageSchema.parse({
-            type: 'release',
-            version: nextVersion,
-          })
-        ),
+        message: { type: 'release', version: nextVersion },
       });
 
       // Switch back to work and sync the version commit
@@ -324,12 +318,7 @@ export class ReleaseService extends AbstractCrudService {
       // Tag on work (not production)
       await this.gitService.tags.create({
         path: projectPath,
-        message: JSON.stringify(
-          releaseTagMessageSchema.parse({
-            type: 'preview',
-            version: previewVersion,
-          })
-        ),
+        message: { type: 'preview', version: previewVersion },
       });
     } catch (error) {
       // Ensure we stay on work branch on failure
@@ -1108,9 +1097,6 @@ export class ReleaseService extends AbstractCrudService {
 
   /**
    * Counts existing preview tags for a given base version since the last full release.
-   *
-   * Parses all tag messages looking for `{ type: 'preview', version: 'X.Y.Z-preview.N' }`
-   * where the base version matches.
    */
   private async countPreviewsSinceLastRelease(
     projectPath: string,
@@ -1120,24 +1106,16 @@ export class ReleaseService extends AbstractCrudService {
     let count = 0;
 
     for (const tag of tags.list) {
-      let rawMessage: unknown = null;
-      try {
-        rawMessage = JSON.parse(tag.message);
-      } catch {
-        // Not JSON, skip
-      }
-      const parsed = releaseTagMessageSchema.safeParse(rawMessage);
+      if (tag.message.type === 'upgrade') continue;
 
-      if (!parsed.success) continue;
-
-      if (parsed.data.type === 'release') {
+      if (tag.message.type === 'release') {
         // Hit the last full release — stop counting
         break;
       }
 
-      if (parsed.data.type === 'preview') {
+      if (tag.message.type === 'preview') {
         // Check if this preview is for the same base version
-        const previewBase = parsed.data.version.split('-')[0];
+        const previewBase = tag.message.version.split('-')[0];
         if (previewBase === baseVersion) {
           count++;
         }

--- a/src/service/ReleaseService.ts
+++ b/src/service/ReleaseService.ts
@@ -672,7 +672,11 @@ export class ReleaseService extends AbstractCrudService {
     // Deleted assets (in production but not in current) — MAJOR
     for (const [id] of productionById) {
       if (!currentById.has(id)) {
-        assetChanges.push({ assetId: id, changeType: 'deleted', bump: 'major' });
+        assetChanges.push({
+          assetId: id,
+          changeType: 'deleted',
+          bump: 'major',
+        });
         highestBump = 'major';
       }
     }

--- a/src/service/ReleaseService.ts
+++ b/src/service/ReleaseService.ts
@@ -636,7 +636,7 @@ export class ReleaseService extends AbstractCrudService {
       }
     }
 
-    // PATCH: name, description, status
+    // PATCH: name, description
     if (current.name !== production.name) {
       projectChanges.push({ changeType: 'nameChanged', bump: 'patch' });
       highestBump = this.higherBump(highestBump, 'patch');
@@ -647,11 +647,6 @@ export class ReleaseService extends AbstractCrudService {
         changeType: 'descriptionChanged',
         bump: 'patch',
       });
-      highestBump = this.higherBump(highestBump, 'patch');
-    }
-
-    if (current.status !== production.status) {
-      projectChanges.push({ changeType: 'statusChanged', bump: 'patch' });
       highestBump = this.higherBump(highestBump, 'patch');
     }
 

--- a/src/service/ReleaseService.ts
+++ b/src/service/ReleaseService.ts
@@ -1,7 +1,9 @@
 import { isDeepStrictEqual } from 'node:util';
 import Semver from 'semver';
 import {
+  assetFileSchema,
   collectionFileSchema,
+  entryFileSchema,
   projectBranchSchema,
   projectFileSchema,
   serviceTypeSchema,
@@ -9,12 +11,18 @@ import {
   createReleaseSchema,
   createPreviewReleaseSchema,
   releaseTagMessageSchema,
+  type AssetChange,
+  type AssetFile,
   type CollectionFile,
   type ElekIoCoreOptions,
+  type EntryChange,
+  type EntryFile,
   type FieldDefinition,
   type PrepareReleaseProps,
   type CreateReleaseProps,
   type CreatePreviewReleaseProps,
+  type ProjectChange,
+  type ProjectFile,
   type ReleaseDiff,
   type ReleaseResult,
   type SemverBump,
@@ -24,7 +32,6 @@ import {
 import { pathTo } from '../util/node.js';
 import { datetime } from '../util/shared.js';
 import { AbstractCrudService } from './AbstractCrudService.js';
-import type { CollectionService } from './CollectionService.js';
 import type { GitService } from './GitService.js';
 import type { JsonFileService } from './JsonFileService.js';
 import type { LogService } from './LogService.js';
@@ -39,7 +46,6 @@ import type { ProjectService } from './ProjectService.js';
 export class ReleaseService extends AbstractCrudService {
   private gitService: GitService;
   private jsonFileService: JsonFileService;
-  private collectionService: CollectionService;
   private projectService: ProjectService;
 
   constructor(
@@ -47,14 +53,12 @@ export class ReleaseService extends AbstractCrudService {
     logService: LogService,
     gitService: GitService,
     jsonFileService: JsonFileService,
-    collectionService: CollectionService,
     projectService: ProjectService
   ) {
     super(serviceTypeSchema.enum.Release, options, logService);
 
     this.gitService = gitService;
     this.jsonFileService = jsonFileService;
-    this.collectionService = collectionService;
     this.projectService = projectService;
   }
 
@@ -78,31 +82,75 @@ export class ReleaseService extends AbstractCrudService {
     const project = await this.projectService.read({ id: props.projectId });
     const currentVersion = project.version;
 
-    // Get current collections from work branch (disk)
-    const currentCollections = await this.collectionService.list({
-      projectId: props.projectId,
-      limit: 0,
-    });
+    const productionRef = projectBranchSchema.enum.production;
 
-    // Get collections from production branch
+    // Diff project settings
+    const productionProject = await this.getProjectAtRef(
+      props.projectId,
+      projectPath,
+      productionRef
+    );
+    const projectDiff = this.diffProject(project, productionProject);
+
+    // Diff collections
+    const currentCollections = await this.getCollectionsAtRef(
+      props.projectId,
+      projectPath,
+      projectBranchSchema.enum.work
+    );
     const productionCollections = await this.getCollectionsAtRef(
       props.projectId,
       projectPath,
-      projectBranchSchema.enum.production
+      productionRef
     );
-
-    // Diff collections
-    const { bump, collectionChanges, fieldChanges } = this.diffCollections(
-      currentCollections.list,
+    const collectionDiff = this.diffCollections(
+      currentCollections,
       productionCollections
     );
 
-    // If no schema changes, check if there are any commits between production and work
-    let finalBump = bump;
+    // Diff assets
+    const currentAssets = await this.getAssetsAtRef(
+      props.projectId,
+      projectPath,
+      projectBranchSchema.enum.work
+    );
+    const productionAssets = await this.getAssetsAtRef(
+      props.projectId,
+      projectPath,
+      productionRef
+    );
+    const assetDiff = this.diffAssets(currentAssets, productionAssets);
+
+    // Diff entries across all collections (union of current and production IDs)
+    const allCollectionIds = new Set([
+      ...currentCollections.map((c) => c.id),
+      ...productionCollections.map((c) => c.id),
+    ]);
+    const entryDiff = await this.diffEntries(
+      props.projectId,
+      projectPath,
+      allCollectionIds,
+      productionRef
+    );
+
+    // Combine bumps from all diffs
+    let finalBump: SemverBump | null = null;
+    for (const bump of [
+      projectDiff.bump,
+      collectionDiff.bump,
+      assetDiff.bump,
+      entryDiff.bump,
+    ]) {
+      if (bump) {
+        finalBump = finalBump ? this.higherBump(finalBump, bump) : bump;
+      }
+    }
+
+    // Fallback: check if there are any commits between production and work
     if (!finalBump) {
       const hasContentChanges = await this.hasCommitsBetween(
         projectPath,
-        projectBranchSchema.enum.production,
+        productionRef,
         projectBranchSchema.enum.work
       );
       if (hasContentChanges) {
@@ -119,8 +167,11 @@ export class ReleaseService extends AbstractCrudService {
       bump: finalBump,
       currentVersion,
       nextVersion,
-      collectionChanges,
-      fieldChanges,
+      projectChanges: projectDiff.projectChanges,
+      collectionChanges: collectionDiff.collectionChanges,
+      fieldChanges: collectionDiff.fieldChanges,
+      assetChanges: assetDiff.assetChanges,
+      entryChanges: entryDiff.entryChanges,
     };
   }
 
@@ -302,6 +353,115 @@ export class ReleaseService extends AbstractCrudService {
   }
 
   /**
+   * Reads the project file as it exists at a given git ref
+   */
+  private async getProjectAtRef(
+    projectId: string,
+    projectPath: string,
+    ref: string
+  ): Promise<ProjectFile | null> {
+    try {
+      const content = await this.gitService.getFileContentAtCommit(
+        projectPath,
+        pathTo.projectFile(projectId),
+        ref
+      );
+      return projectFileSchema.parse(JSON.parse(content));
+    } catch {
+      // Project may not exist at this ref (first release scenario)
+      return null;
+    }
+  }
+
+  /**
+   * Reads asset metadata files as they exist at a given git ref
+   */
+  private async getAssetsAtRef(
+    projectId: string,
+    projectPath: string,
+    ref: string
+  ): Promise<AssetFile[]> {
+    const assetsPath = pathTo.assets(projectId);
+
+    const fileNames = await this.gitService.listTreeAtCommit(
+      projectPath,
+      assetsPath,
+      ref
+    );
+
+    const assets: AssetFile[] = [];
+
+    for (const fileName of fileNames) {
+      if (!fileName.endsWith('.json')) continue;
+
+      const assetId = fileName.replace('.json', '');
+      const assetFilePath = pathTo.assetFile(projectId, assetId);
+
+      try {
+        const content = await this.gitService.getFileContentAtCommit(
+          projectPath,
+          assetFilePath,
+          ref
+        );
+        const assetFile = assetFileSchema.parse(JSON.parse(content));
+        assets.push(assetFile);
+      } catch {
+        this.logService.debug({
+          source: 'core',
+          message: `Skipping asset "${fileName}" at ref "${ref}" during release diff`,
+        });
+      }
+    }
+
+    return assets;
+  }
+
+  /**
+   * Reads entry files for a single collection as they exist at a given git ref
+   */
+  private async getEntriesAtRef(
+    projectId: string,
+    projectPath: string,
+    collectionId: string,
+    ref: string
+  ): Promise<EntryFile[]> {
+    const entriesPath = pathTo.entries(projectId, collectionId);
+
+    const fileNames = await this.gitService.listTreeAtCommit(
+      projectPath,
+      entriesPath,
+      ref
+    );
+
+    const entries: EntryFile[] = [];
+
+    for (const fileName of fileNames) {
+      if (!fileName.endsWith('.json') || fileName === 'collection.json')
+        continue;
+
+      const entryId = fileName.replace('.json', '');
+      const entryFilePath = pathTo.entryFile(projectId, collectionId, entryId);
+
+      try {
+        const content = await this.gitService.getFileContentAtCommit(
+          projectPath,
+          entryFilePath,
+          ref
+        );
+        const entryFile = entryFileSchema.parse(JSON.parse(content));
+        entries.push(entryFile);
+      } catch {
+        this.logService.debug({
+          source: 'core',
+          message: `Skipping entry "${fileName}" in collection "${collectionId}" at ref "${ref}" during release diff`,
+        });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
    * Reads collections as they exist at a given git ref (branch or commit)
    */
   private async getCollectionsAtRef(
@@ -426,6 +586,233 @@ export class ReleaseService extends AbstractCrudService {
     }
 
     return { bump: highestBump, collectionChanges, fieldChanges };
+  }
+
+  /**
+   * Diffs the project file between current and production.
+   *
+   * Skips immutable/system-managed fields (id, objectType, created, updated, version, coreVersion).
+   */
+  private diffProject(
+    current: ProjectFile,
+    production: ProjectFile | null
+  ): {
+    bump: SemverBump | null;
+    projectChanges: ProjectChange[];
+  } {
+    const projectChanges: ProjectChange[] = [];
+
+    // No production project means first release — no changes to report
+    if (!production) {
+      return { bump: null, projectChanges };
+    }
+
+    let highestBump: SemverBump | null = null;
+
+    // MAJOR: default language changed
+    if (
+      current.settings.language.default !== production.settings.language.default
+    ) {
+      projectChanges.push({
+        changeType: 'defaultLanguageChanged',
+        bump: 'major',
+      });
+      highestBump = 'major';
+    }
+
+    // MAJOR: supported language removed
+    const currentSupported = new Set(current.settings.language.supported);
+    const productionSupported = new Set(production.settings.language.supported);
+
+    for (const lang of productionSupported) {
+      if (!currentSupported.has(lang)) {
+        projectChanges.push({
+          changeType: 'supportedLanguageRemoved',
+          bump: 'major',
+        });
+        highestBump = 'major';
+        break;
+      }
+    }
+
+    // MINOR: supported language added
+    for (const lang of currentSupported) {
+      if (!productionSupported.has(lang)) {
+        projectChanges.push({
+          changeType: 'supportedLanguageAdded',
+          bump: 'minor',
+        });
+        highestBump = this.higherBump(highestBump, 'minor');
+        break;
+      }
+    }
+
+    // PATCH: name, description, status
+    if (current.name !== production.name) {
+      projectChanges.push({ changeType: 'nameChanged', bump: 'patch' });
+      highestBump = this.higherBump(highestBump, 'patch');
+    }
+
+    if (current.description !== production.description) {
+      projectChanges.push({
+        changeType: 'descriptionChanged',
+        bump: 'patch',
+      });
+      highestBump = this.higherBump(highestBump, 'patch');
+    }
+
+    if (current.status !== production.status) {
+      projectChanges.push({ changeType: 'statusChanged', bump: 'patch' });
+      highestBump = this.higherBump(highestBump, 'patch');
+    }
+
+    return { bump: highestBump, projectChanges };
+  }
+
+  /**
+   * Diffs two sets of assets and returns all changes with the computed bump level.
+   */
+  private diffAssets(
+    currentAssets: AssetFile[],
+    productionAssets: AssetFile[]
+  ): {
+    bump: SemverBump | null;
+    assetChanges: AssetChange[];
+  } {
+    const assetChanges: AssetChange[] = [];
+    let highestBump: SemverBump | null = null;
+
+    const currentById = new Map(currentAssets.map((a) => [a.id, a]));
+    const productionById = new Map(productionAssets.map((a) => [a.id, a]));
+
+    // Deleted assets (in production but not in current) — MAJOR
+    for (const [id] of productionById) {
+      if (!currentById.has(id)) {
+        assetChanges.push({ assetId: id, changeType: 'deleted', bump: 'major' });
+        highestBump = 'major';
+      }
+    }
+
+    // New assets (in current but not in production) — MINOR
+    for (const [id] of currentById) {
+      if (!productionById.has(id)) {
+        assetChanges.push({ assetId: id, changeType: 'added', bump: 'minor' });
+        highestBump = this.higherBump(highestBump, 'minor');
+      }
+    }
+
+    // Modified assets — compare properties
+    for (const [id, current] of currentById) {
+      const production = productionById.get(id);
+      if (!production) continue;
+
+      // Binary changed (extension, mimeType, or size differ) — PATCH
+      if (
+        current.extension !== production.extension ||
+        current.mimeType !== production.mimeType ||
+        current.size !== production.size
+      ) {
+        assetChanges.push({
+          assetId: id,
+          changeType: 'binaryChanged',
+          bump: 'patch',
+        });
+        highestBump = this.higherBump(highestBump, 'patch');
+      }
+
+      // Metadata changed (name or description differ) — PATCH
+      if (
+        current.name !== production.name ||
+        current.description !== production.description
+      ) {
+        assetChanges.push({
+          assetId: id,
+          changeType: 'metadataChanged',
+          bump: 'patch',
+        });
+        highestBump = this.higherBump(highestBump, 'patch');
+      }
+    }
+
+    return { bump: highestBump, assetChanges };
+  }
+
+  /**
+   * Diffs entries across all collections between current and production.
+   */
+  private async diffEntries(
+    projectId: string,
+    projectPath: string,
+    allCollectionIds: Set<string>,
+    productionRef: string
+  ): Promise<{
+    bump: SemverBump | null;
+    entryChanges: EntryChange[];
+  }> {
+    const entryChanges: EntryChange[] = [];
+    let highestBump: SemverBump | null = null;
+
+    for (const collectionId of allCollectionIds) {
+      const currentEntries = await this.getEntriesAtRef(
+        projectId,
+        projectPath,
+        collectionId,
+        projectBranchSchema.enum.work
+      );
+      const productionEntries = await this.getEntriesAtRef(
+        projectId,
+        projectPath,
+        collectionId,
+        productionRef
+      );
+
+      const currentById = new Map(currentEntries.map((e) => [e.id, e]));
+      const productionById = new Map(productionEntries.map((e) => [e.id, e]));
+
+      // Deleted entries — MAJOR
+      for (const [id] of productionById) {
+        if (!currentById.has(id)) {
+          entryChanges.push({
+            collectionId,
+            entryId: id,
+            changeType: 'deleted',
+            bump: 'major',
+          });
+          highestBump = 'major';
+        }
+      }
+
+      // New entries — MINOR
+      for (const [id] of currentById) {
+        if (!productionById.has(id)) {
+          entryChanges.push({
+            collectionId,
+            entryId: id,
+            changeType: 'added',
+            bump: 'minor',
+          });
+          highestBump = this.higherBump(highestBump, 'minor');
+        }
+      }
+
+      // Modified entries — PATCH
+      for (const [id, current] of currentById) {
+        const production = productionById.get(id);
+        if (!production) continue;
+
+        if (!isDeepStrictEqual(current.values, production.values)) {
+          entryChanges.push({
+            collectionId,
+            entryId: id,
+            changeType: 'modified',
+            bump: 'patch',
+          });
+          highestBump = this.higherBump(highestBump, 'patch');
+        }
+      }
+    }
+
+    return { bump: highestBump, entryChanges };
   }
 
   /**

--- a/src/service/UserService.ts
+++ b/src/service/UserService.ts
@@ -1,5 +1,5 @@
 import {
-  UserTypeSchema,
+  userTypeSchema,
   setUserSchema,
   userFileSchema,
   type SetUserProps,
@@ -49,7 +49,7 @@ export class UserService {
       ...props,
     };
 
-    if (userFile.userType === UserTypeSchema.enum.cloud) {
+    if (userFile.userType === userTypeSchema.enum.cloud) {
       // Try logging in the user
       // Throw on Error
     }

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -7,4 +7,5 @@ export * from './GitTagService.js';
 export * from './JsonFileService.js';
 export * from './LogService.js';
 export * from './ProjectService.js';
+export * from './ReleaseService.js';
 export * from './UserService.js';

--- a/src/service/migrations/applyMigrations.test.ts
+++ b/src/service/migrations/applyMigrations.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { Migration } from '../../schema/migrationSchema.js';
+import { applyMigrations } from './applyMigrations.js';
+
+describe('applyMigrations', () => {
+  it('stamps version and leaves data unchanged when migration array is empty', () => {
+    const data = { coreVersion: '1.0.0', name: 'test' };
+    const result = applyMigrations(data, [], '2.0.0');
+
+    expect(result['coreVersion']).toBe('2.0.0');
+    expect(result['name']).toBe('test');
+    // Original must not be mutated
+    expect(data.coreVersion).toBe('1.0.0');
+  });
+
+  it('applies a single migration step', () => {
+    const migrations: Migration[] = [
+      {
+        from: '1.0.0',
+        to: '2.0.0',
+        run: (data) => ({ ...data, newField: 'added' }),
+      },
+    ];
+    const data = { coreVersion: '1.0.0', name: 'test' };
+    const result = applyMigrations(data, migrations, '2.0.0');
+
+    expect(result['coreVersion']).toBe('2.0.0');
+    expect(result['newField']).toBe('added');
+    expect(result['name']).toBe('test');
+  });
+
+  it('applies a multi-step chain sequentially', () => {
+    const migrations: Migration[] = [
+      {
+        from: '1.0.0',
+        to: '1.1.0',
+        run: (data) => ({ ...data, step1: true }),
+      },
+      {
+        from: '1.1.0',
+        to: '2.0.0',
+        run: (data) => ({ ...data, step2: true }),
+      },
+    ];
+    const data = { coreVersion: '1.0.0' };
+    const result = applyMigrations(data, migrations, '2.0.0');
+
+    expect(result['coreVersion']).toBe('2.0.0');
+    expect(result['step1']).toBe(true);
+    expect(result['step2']).toBe(true);
+  });
+
+  it('stamps target version when no migration matches the current version', () => {
+    const migrations: Migration[] = [
+      {
+        from: '1.0.0',
+        to: '1.1.0',
+        run: (data) => ({ ...data, transformed: true }),
+      },
+    ];
+    // Starting at 1.5.0, no migration from 1.5.0 exists
+    const data = { coreVersion: '1.5.0', name: 'test' };
+    const result = applyMigrations(data, migrations, '2.0.0');
+
+    expect(result['coreVersion']).toBe('2.0.0');
+    expect(result['name']).toBe('test');
+    expect(result['transformed']).toBeUndefined();
+  });
+
+  it('does not mutate the original data (deep clone)', () => {
+    const migrations: Migration[] = [
+      {
+        from: '1.0.0',
+        to: '2.0.0',
+        run: (data) => {
+          const result = { ...data };
+          result['nested'] = { changed: true };
+          return result;
+        },
+      },
+    ];
+    const data = { coreVersion: '1.0.0', nested: { original: true } };
+    const result = applyMigrations(data, migrations, '2.0.0');
+
+    expect((data.nested as Record<string, unknown>)['original']).toBe(true);
+    expect((data.nested as Record<string, unknown>)['changed']).toBeUndefined();
+    expect((result['nested'] as Record<string, unknown>)['changed']).toBe(true);
+  });
+
+  it('returns data unchanged when already at target version', () => {
+    const data = { coreVersion: '2.0.0', name: 'test' };
+    const result = applyMigrations(data, [], '2.0.0');
+
+    expect(result['coreVersion']).toBe('2.0.0');
+    expect(result['name']).toBe('test');
+  });
+});

--- a/src/service/migrations/applyMigrations.ts
+++ b/src/service/migrations/applyMigrations.ts
@@ -1,0 +1,23 @@
+import type { Migration } from '../../schema/migrationSchema.js';
+import type { Version } from '../../schema/baseSchema.js';
+
+export function applyMigrations(
+  data: Record<string, unknown>,
+  migrations: Migration[],
+  targetVersion: Version
+): Record<string, unknown> {
+  let current = structuredClone(data);
+
+  while (current['coreVersion'] !== targetVersion) {
+    const migration = migrations.find((m) => m.from === current['coreVersion']);
+    if (!migration) {
+      // No migration registered for this version gap — assume backward-compatible
+      current['coreVersion'] = targetVersion;
+      break;
+    }
+    current = migration.run(current);
+    current['coreVersion'] = migration.to;
+  }
+
+  return current;
+}

--- a/src/service/migrations/assetMigrations.ts
+++ b/src/service/migrations/assetMigrations.ts
@@ -1,0 +1,3 @@
+import type { Migration } from '../../schema/migrationSchema.js';
+
+export const assetMigrations: Migration[] = [];

--- a/src/service/migrations/collectionMigrations.ts
+++ b/src/service/migrations/collectionMigrations.ts
@@ -1,0 +1,3 @@
+import type { Migration } from '../../schema/migrationSchema.js';
+
+export const collectionMigrations: Migration[] = [];

--- a/src/service/migrations/entryMigrations.ts
+++ b/src/service/migrations/entryMigrations.ts
@@ -1,0 +1,3 @@
+import type { Migration } from '../../schema/migrationSchema.js';
+
+export const entryMigrations: Migration[] = [];

--- a/src/service/migrations/index.ts
+++ b/src/service/migrations/index.ts
@@ -1,0 +1,5 @@
+export { applyMigrations } from './applyMigrations.js';
+export { assetMigrations } from './assetMigrations.js';
+export { collectionMigrations } from './collectionMigrations.js';
+export { entryMigrations } from './entryMigrations.js';
+export { projectMigrations } from './projectMigrations.js';

--- a/src/service/migrations/projectMigrations.ts
+++ b/src/service/migrations/projectMigrations.ts
@@ -1,0 +1,3 @@
+import type { Migration } from '../../schema/migrationSchema.js';
+
+export const projectMigrations: Migration[] = [];

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -7,10 +7,16 @@ import { expect } from 'vitest';
 import type { EntryFieldDefinition } from './setup.js';
 import core, { uuid, type ProjectSettings } from './setup.js';
 
-const id = {
+const ids = {
   textFieldDefinition: uuid(),
   assetReferenceFieldDefinition: uuid(),
   entryReferenceFieldDefinition: uuid(),
+};
+
+const slugs = {
+  textFieldDefinition: 'product-name',
+  assetReferenceFieldDefinition: 'header-image',
+  entryReferenceFieldDefinition: 'related-products',
 };
 
 export async function ensureCleanGitStatus(
@@ -117,7 +123,8 @@ export async function createCollection(projectId: string) {
     },
     fieldDefinitions: [
       {
-        id: id.textFieldDefinition,
+        id: ids.textFieldDefinition,
+        slug: slugs.textFieldDefinition,
         valueType: 'string',
         label: {
           en: 'Name',
@@ -135,7 +142,8 @@ export async function createCollection(projectId: string) {
         max: 70,
       },
       {
-        id: id.assetReferenceFieldDefinition,
+        id: ids.assetReferenceFieldDefinition,
+        slug: slugs.assetReferenceFieldDefinition,
         valueType: 'reference',
         label: {
           en: 'Header image',
@@ -152,7 +160,8 @@ export async function createCollection(projectId: string) {
         max: null,
       },
       {
-        id: id.entryReferenceFieldDefinition,
+        id: ids.entryReferenceFieldDefinition,
+        slug: slugs.entryReferenceFieldDefinition,
         valueType: 'reference',
         label: {
           en: 'Related products',
@@ -175,9 +184,9 @@ export async function createCollection(projectId: string) {
   // Add circular reference to products
   (
     collection.fieldDefinitions.find((definition) => {
-      return definition.id === id.entryReferenceFieldDefinition;
+      return definition.slug === slugs.entryReferenceFieldDefinition;
     }) as EntryFieldDefinition
-  ).ofCollections = [id.entryReferenceFieldDefinition];
+  ).ofCollections = [collection.id];
 
   const updatedCollection = await core.collections.update({
     ...collection,
@@ -196,19 +205,17 @@ export async function createEntry(
   const entry = await core.entries.create({
     projectId: projectId,
     collectionId: collectionId,
-    values: [
-      {
+    values: {
+      [slugs.textFieldDefinition]: {
         objectType: 'value',
         valueType: 'string',
-        fieldDefinitionId: id.textFieldDefinition,
         content: {
           en: faker.commerce.product(),
         },
       },
-      {
+      [slugs.assetReferenceFieldDefinition]: {
         objectType: 'value',
         valueType: 'reference',
-        fieldDefinitionId: id.assetReferenceFieldDefinition,
         content: {
           en: [
             {
@@ -218,10 +225,9 @@ export async function createEntry(
           ],
         },
       },
-      {
+      [slugs.entryReferenceFieldDefinition]: {
         objectType: 'value',
         valueType: 'reference',
-        fieldDefinitionId: id.entryReferenceFieldDefinition,
         content: {
           en:
             (entryValueId && [
@@ -233,7 +239,7 @@ export async function createEntry(
             [],
         },
       },
-    ],
+    },
   });
 
   return entry;

--- a/src/util/node.ts
+++ b/src/util/node.ts
@@ -51,6 +51,9 @@ export const pathTo = {
   collectionFile: (projectId: string, id: string) => {
     return Path.join(pathTo.collection(projectId, id), 'collection.json');
   },
+  collectionIndex: (projectId: string) => {
+    return Path.join(pathTo.collections(projectId), 'index.json');
+  },
 
   entries: (projectId: string, collectionId: string): string => {
     return Path.join(pathTo.collection(projectId, collectionId));


### PR DESCRIPTION
- Added Collection read by slug. Entry values are now accessed by slug (record instead of array). Important for consumers via API and Astro integration
- New `ReleaseService` that diffs the `work` branch against `production` to detect collection and field definition changes, computes the appropriate semver bump (major/minor/patch), and supports creating full releases and preview releases with git tags.
- Added a migration chain for outdated files (reading from git history and upgrading to the latest schema version)
- Added documentation for the migration and history-reading flow in `docs/migration-and-history-flow.md`
- Separated git history from CRUD return values
- Git commit messages now use human-readable subject lines with git trailers (Method:, Object-Type:, Object-Id:, Collection-Id:) instead of JSON.stringify
- Git tag messages use a typed GitTagMessage discriminated union (release, preview, upgrade) serialized as git trailers (Type:, Version:, Core-Version:)
- Removed releaseTypeSchema and releaseTagMessageSchema from releaseSchema.ts — tag message typing now lives in gitSchema.ts
- Tightened Zod schemas: commit hash uses z.hash('sha1'), datetimes use z.iso.datetime(), migrateProjectSchema uses z.looseObject()
- Fixed email truncation bug in GitTagService.list() caused by a redundant slice(0, -1)
- Added pipe-character validation on gitSignatureSchema.name to prevent delimiter collision in parsed output
- Changed parseTagTrailers to return null and log a warning for unrecognized tag types instead of throwing
- Separated git history from CRUD return values for improved performance. `history` and `fullHistory` are no longer included on `Project`, `Collection`, `Entry`, and `Asset` objects. Use the new `history()` method on each service instead (e.g. `core.projects.history({ id })`, `core.entries.history({ projectId, collectionId, id })`).